### PR TITLE
Restrict report retrieval to privileged roles

### DIFF
--- a/backend/app/api/v1/routes_reports.py
+++ b/backend/app/api/v1/routes_reports.py
@@ -25,7 +25,7 @@ def create_report(
 @router.get("/{report_id}")
 def get_report(
     report_id: int,
-    current_user: User = Depends(auth.get_current_user),
+    current_user: User = Depends(auth.require_roles(UserRole.DOCTOR, UserRole.ADMIN)),
     report_repo: repositories.ReportRepository = Depends(deps.get_report_repository),
 ):
     report = report_repo.get(report_id)


### PR DESCRIPTION
## Summary
- enforce doctor and admin role checks when retrieving reports to prevent unauthorized access

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690cecd81dd4832e8dc56f9fb546eddc