### PR TITLE
Allow configuring multiple frontend origins

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -21,7 +21,7 @@ app = FastAPI(title=settings.APP_NAME, version="1.0.0")
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[settings.FRONTEND_ORIGIN],
+    allow_origins=settings.frontend_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -19,7 +19,16 @@ class Settings(BaseSettings):
     STORAGE_KEY: str
     STORAGE_SECRET: str
 
-    FRONTEND_ORIGIN: str = "http://localhost:3000"
+    FRONTEND_ORIGIN: str = "http://localhost:3000,http://localhost:5173"
+
+    @property
+    def frontend_origins(self) -> list[str]:
+        """Return the configured list of frontend origins for CORS."""
+        return [
+            origin.strip()
+            for origin in self.FRONTEND_ORIGIN.split(",")
+            if origin.strip()
+        ]
 
     ASR_MODEL: str = "whisper-large"  # TODO: used by AI team
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,12 +1,39 @@
-# React + Vite
+# MedTranscribe Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This React + Vite application provides the user interface for the MedTranscribe platform. It connects to the FastAPI backend for authentication, job management, and audio uploads.
 
-Currently, two official plugins are available:
+## Getting Started
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+```bash
+cd frontend
+npm install
+npm run dev
+```
 
-## Expanding the ESLint configuration
+The app expects the backend to be running (default: `http://localhost:8000`). Configure the API base URL via a Vite environment variable:
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+```bash
+# frontend/.env
+VITE_API_BASE_URL=http://localhost:8000
+```
+
+Restart the dev server whenever you change environment variables.
+
+## Available Scripts
+
+- `npm run dev` – start the development server with hot reloading.
+- `npm run build` – create a production build.
+- `npm run preview` – preview the production build locally.
+
+## Authentication Flow
+
+- Registration and login flows exchange credentials with the backend and store a JWT access token in `localStorage`.
+- Protected dashboard routes require a valid session; unauthenticated users are redirected to `/login`.
+- Session details are fetched from `/v1/auth/me` to populate the UI.
+
+## Transcription Workflow
+
+- Upload audio files from the **New Transcription** page. Files are posted to `/v1/transcribe/upload` and automatically create a job via `/v1/jobs`.
+- Monitor processing status from the **History** page, which lists jobs returned by `/v1/jobs`.
+
+Ensure CORS on the backend allows the origin used by the frontend (`FRONTEND_ORIGIN` in backend settings).

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from "react-router-dom";
 //forked repo changes made
 import { Routerset } from "./routes/Routerset";
 import { ThemeProvider } from "./context/ThemeContext";
-import { UserProvider } from "./context/UserContext";
+import { UserProvider } from "./context/UserContext.jsx";
 
 function App() {
   return (

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -1,0 +1,113 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "http://localhost:8000";
+
+const buildHeaders = (token, extra = {}) => {
+  const headers = {
+    Accept: "application/json",
+    ...extra,
+  };
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+  }
+  return headers;
+};
+
+const handleResponse = async (response) => {
+  if (!response.ok) {
+    let message = response.statusText;
+    try {
+      const errorData = await response.json();
+      if (errorData?.detail) {
+        message = Array.isArray(errorData.detail)
+          ? errorData.detail.map((item) => item.msg || item).join(", ")
+          : errorData.detail;
+      } else if (errorData?.message) {
+        message = errorData.message;
+      }
+    } catch (error) {
+      // ignore JSON parse errors
+    }
+    throw new Error(message || "Request failed");
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  const contentType = response.headers.get("content-type");
+  if (contentType && contentType.includes("application/json")) {
+    return response.json();
+  }
+  return response.text();
+};
+
+export const login = async (username, password) => {
+  const body = new URLSearchParams();
+  body.append("username", username);
+  body.append("password", password);
+
+  const response = await fetch(`${API_BASE_URL}/v1/auth/token`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body,
+  });
+
+  return handleResponse(response);
+};
+
+export const register = async ({ username, password, role }) => {
+  const response = await fetch(`${API_BASE_URL}/v1/auth/register`, {
+    method: "POST",
+    headers: buildHeaders(null, { "Content-Type": "application/json" }),
+    body: JSON.stringify({ username, password, role }),
+  });
+
+  return handleResponse(response);
+};
+
+export const getCurrentUser = async (token) => {
+  const response = await fetch(`${API_BASE_URL}/v1/auth/me`, {
+    method: "GET",
+    headers: buildHeaders(token),
+  });
+
+  return handleResponse(response);
+};
+
+export const listJobs = async (token) => {
+  const response = await fetch(`${API_BASE_URL}/v1/jobs`, {
+    method: "GET",
+    headers: buildHeaders(token),
+  });
+
+  return handleResponse(response);
+};
+
+export const createJob = async (token, payload) => {
+  const response = await fetch(`${API_BASE_URL}/v1/jobs`, {
+    method: "POST",
+    headers: buildHeaders(token, { "Content-Type": "application/json" }),
+    body: JSON.stringify(payload),
+  });
+
+  return handleResponse(response);
+};
+
+export const uploadTranscription = async (token, file) => {
+  const formData = new FormData();
+  formData.append("file", file);
+
+  const response = await fetch(`${API_BASE_URL}/v1/transcribe/upload`, {
+    method: "POST",
+    headers: buildHeaders(token),
+    body: formData,
+  });
+
+  return handleResponse(response);
+};
+
+export const apiConfig = {
+  API_BASE_URL,
+};

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -1,25 +1,136 @@
-import { createContext, useContext, useState } from "react";
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import * as api from "../api/client";
 
-// Create context
 const UserContext = createContext();
+const TOKEN_STORAGE_KEY = "medtranscribe_access_token";
 
-// Provider component
+const normalizeUser = (user) => ({
+  id: user.id,
+  username: user.username,
+  name: user.username,
+  role: user.role,
+  createdAt: user.created_at,
+  updatedAt: user.updated_at,
+});
+
 export const UserProvider = ({ children }) => {
-  const [user, setUser] = useState({
-    name: "Rifab Ahamed",
-    role: "doctor", // doctor | transcriptionist | admin
-    specialty: "Cardiology", // optional for doctors
-  });
+  const [user, setUser] = useState(null);
+  const [token, setToken] = useState(() => localStorage.getItem(TOKEN_STORAGE_KEY));
+  const [loading, setLoading] = useState(Boolean(localStorage.getItem(TOKEN_STORAGE_KEY)));
+  const skipAutoFetch = useRef(false);
 
-  // You can update user anywhere in app with setUser
-  return (
-    <UserContext.Provider value={{ user, setUser }}>
-      {children}
-    </UserContext.Provider>
+  const loadUser = useCallback(
+    async (authToken) => {
+      const profile = await api.getCurrentUser(authToken);
+      const normalized = normalizeUser(profile);
+      setUser(normalized);
+      return normalized;
+    },
+    []
   );
+
+  useEffect(() => {
+    let active = true;
+
+    if (!token) {
+      setUser(null);
+      setLoading(false);
+      return undefined;
+    }
+
+    if (skipAutoFetch.current) {
+      skipAutoFetch.current = false;
+      return undefined;
+    }
+
+    if (user) {
+      setLoading(false);
+      return undefined;
+    }
+
+    setLoading(true);
+    (async () => {
+      try {
+        await loadUser(token);
+      } catch (error) {
+        if (!active) {
+          return;
+        }
+        console.error("Failed to load current user", error);
+        localStorage.removeItem(TOKEN_STORAGE_KEY);
+        setToken(null);
+        setUser(null);
+      } finally {
+        if (active) {
+          setLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [token, user, loadUser]);
+
+  const login = useCallback(
+    async (username, password) => {
+      setLoading(true);
+      try {
+        const authResponse = await api.login(username, password);
+        skipAutoFetch.current = true;
+        localStorage.setItem(TOKEN_STORAGE_KEY, authResponse.access_token);
+        setToken(authResponse.access_token);
+        await loadUser(authResponse.access_token);
+        return authResponse;
+      } catch (error) {
+        localStorage.removeItem(TOKEN_STORAGE_KEY);
+        setToken(null);
+        setUser(null);
+        throw error;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [loadUser]
+  );
+
+  const register = useCallback(
+    async ({ username, password, role }) => {
+      await api.register({ username, password, role });
+      await login(username, password);
+    },
+    [login]
+  );
+
+  const logout = useCallback(() => {
+    localStorage.removeItem(TOKEN_STORAGE_KEY);
+    setToken(null);
+    setUser(null);
+  }, []);
+
+  const refreshUser = useCallback(async () => {
+    if (!token) {
+      return null;
+    }
+    const profile = await loadUser(token);
+    return profile;
+  }, [token, loadUser]);
+
+  const value = useMemo(
+    () => ({
+      user,
+      token,
+      loading,
+      login,
+      register,
+      logout,
+      refreshUser,
+      isAuthenticated: Boolean(user && token),
+    }),
+    [user, token, loading, login, register, logout, refreshUser]
+  );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
 };
 
-// Custom hook for easy access
-export const useUser = () => {
-  return useContext(UserContext);
-};
+export const useUser = () => useContext(UserContext);

--- a/frontend/src/layout/DashboardLayout.jsx
+++ b/frontend/src/layout/DashboardLayout.jsx
@@ -1,14 +1,12 @@
-import React, { useEffect } from "react";
-import { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Header } from "../layout/Header.jsx";
 import { Sidebar } from "./Sidebar.jsx";
 import { Outlet } from "react-router-dom";
 import { useUser } from "../context/UserContext.jsx";
 
-const DashboardLayout = ({ onLogout }) => {
+const DashboardLayout = () => {
   const [sidebarOpen, setSidebarOpen] = useState(true);
-
-  const { user } = useUser();
+  const { user, logout } = useUser();
 
   useEffect(() => {
     if (window.innerWidth < 768) {
@@ -29,14 +27,11 @@ const DashboardLayout = ({ onLogout }) => {
 
   return (
     <div className="flex h-screen bg-background">
-      <Sidebar
-        isOpen={sidebarOpen}
-        onToggle={() => setSidebarOpen(!sidebarOpen)}
-      />
+      <Sidebar isOpen={sidebarOpen} onToggle={() => setSidebarOpen(!sidebarOpen)} />
       <div className="flex-1 flex flex-col overflow-hidden">
         <Header
           user={user}
-          onLogout={onLogout}
+          onLogout={logout}
           onToggleSidebar={() => setSidebarOpen(!sidebarOpen)}
         />
         <main className="flex-1 overflow-auto p-2 sm:p-6">

--- a/frontend/src/layout/Header.jsx
+++ b/frontend/src/layout/Header.jsx
@@ -1,14 +1,19 @@
-import { Button, ConfigProvider, Dropdown, Switch } from "antd";
+import { Button, ConfigProvider, Dropdown, Switch, message } from "antd";
 import { User, Settings, LogOut, Moon, Sun } from "lucide-react";
 import { useTheme } from "../context/ThemeContext.jsx";
 
 export const Header = ({ onLogout, user }) => {
   const { theme, toggleTheme } = useTheme();
 
-  const handleLogout = () => {
-    localStorage.removeItem("user");
-    onLogout();
+  const handleLogout = async () => {
+    try {
+      onLogout?.();
+    } catch (error) {
+      message.error(error?.message ?? "Unable to logout");
+    }
   };
+
+  const firstName = user?.name?.split(" ")[0] ?? user?.username ?? "there";
 
   const menuItems = [
     {
@@ -35,18 +40,10 @@ export const Header = ({ onLogout, user }) => {
       label: (
         <div className="flex items-center justify-between gap-2 w-full">
           <div className="flex items-center gap-2">
-            {theme === "dark" ? (
-              <Moon className="w-4 h-4" />
-            ) : (
-              <Sun className="w-4 h-4" />
-            )}
+            {theme === "dark" ? <Moon className="w-4 h-4" /> : <Sun className="w-4 h-4" />}
             <span>Dark Mode</span>
           </div>
-          <Switch
-            size="small"
-            checked={theme === "dark"}
-            onChange={toggleTheme}
-          />
+          <Switch size="small" checked={theme === "dark"} onChange={toggleTheme} />
         </div>
       ),
     },
@@ -68,19 +65,9 @@ export const Header = ({ onLogout, user }) => {
     <header className="bg-background border-b border-border px-1 md:px-6 py-2 md:py-4">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-4">
-          {/* <Button
-            variant="ghost"
-            size="sm"
-            onClick={onToggleSidebar}
-            className="md:hidden"
-          >
-            <MenuIcon className="w-5 h-5" />
-          </Button> */}
-
           <div>
             <h1 className="xs:text-sm md:text-xl font-semibold text-foreground">
-              Welcome back,
-              {user.name.split(" ")[0]}
+              Welcome back, {firstName}
             </h1>
             <p className="text-sm text-muted-foreground">
               {new Date().toLocaleDateString("en-US", {
@@ -105,18 +92,12 @@ export const Header = ({ onLogout, user }) => {
             },
           }}
         >
-          <Dropdown
-            menu={{ items: menuItems }}
-            placement="bottomRight"
-            trigger={["click"]}
-          >
+          <Dropdown menu={{ items: menuItems }} placement="bottomRight" trigger={["click"]}>
             <Button type="text" className="flex items-center gap-2">
               <div className="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center">
                 <User className="w-4 h-4 text-white" />
               </div>
-              <span className="hidden md:inline text-foreground">
-                {user.name}
-              </span>
+              <span className="hidden md:inline text-foreground">{user?.name ?? user?.username ?? "User"}</span>
             </Button>
           </Dropdown>
         </ConfigProvider>

--- a/frontend/src/layout/Sidebar.jsx
+++ b/frontend/src/layout/Sidebar.jsx
@@ -11,23 +11,21 @@ import {
 } from "lucide-react";
 import { useUser } from "../context/UserContext.jsx";
 import { NavLink } from "react-router-dom";
-// import { useState } from "react";
 
-export const Sidebar = ({
-  // currentPage,
-  // onNavigate,
-  isOpen,
-  onToggle,
-}) => {
-  // const location = useLocation();
+export const Sidebar = ({ isOpen, onToggle }) => {
   const { user } = useUser();
+
+  if (!user) {
+    return null;
+  }
+
   const menuItems = [
     {
       id: "home",
       label: "Home",
       icon: Home,
       path: "/dashboard",
-      roles: ["doctor", "transcriptionist", "admin"],
+      roles: ["doctor", "transcriptionist", "admin", "assistant"],
     },
     {
       id: "new-transcription",
@@ -41,7 +39,7 @@ export const Sidebar = ({
       label: "History",
       icon: History,
       path: "/dashboard/history",
-      roles: ["doctor", "transcriptionist", "admin"],
+      roles: ["doctor", "transcriptionist", "admin", "assistant"],
     },
     {
       id: "review",
@@ -62,13 +60,11 @@ export const Sidebar = ({
       label: "Settings",
       icon: Settings,
       path: "/dashboard/settings",
-      roles: ["doctor", "transcriptionist", "admin"],
+      roles: ["doctor", "transcriptionist", "admin", "assistant"],
     },
   ];
 
-  const filteredMenuItems = menuItems.filter((item) =>
-    item.roles.includes(user.role)
-  );
+  const filteredMenuItems = menuItems.filter((item) => item.roles.includes(user.role));
 
   return (
     <div
@@ -76,37 +72,26 @@ export const Sidebar = ({
         isOpen ? "w-48" : "w-14"
       }`}
     >
-      {/* Header */}
       <div className="p-2 md:p-4 border-b border-border">
         <div className="flex flex-col items-center justify-center gap-2">
           <div className={`flex items-center gap-3`}>
             <div className="w-8 h-8 bg-blue-600 rounded-lg flex items-center justify-center">
               <Stethoscope className="w-5 h-5 text-white" />
             </div>
-            {isOpen && (
-              <span className="font-semibold text-foreground">
-                MedTranscribe
-              </span>
-            )}
+            {isOpen && <span className="font-semibold text-foreground">MedTranscribe</span>}
           </div>
           <div className=" w-full flex justify-end">
-            <div
-              // variant="ghost"
-              size="sm"
+            <Button
+              size="small"
+              type="text"
               onClick={onToggle}
-              className="cursor-pointer p-2 rounded-full bg-accent hover:bg-gray-200 transition-colors"
-            >
-              <ChevronLeft
-                className={`text-foreground w-4 h-4 transition-transform ${
-                  !isOpen ? "rotate-180" : ""
-                }`}
-              />
-            </div>
+              className="p-0 text-foreground"
+              icon={<ChevronLeft className={`text-foreground w-4 h-4 ${!isOpen ? "rotate-180" : ""}`} />}
+            />
           </div>
         </div>
       </div>
 
-      {/* Navigation */}
       <nav className="flex-1 p-2 sm:p-4 flex flex-col items-center">
         <ul className="space-y-2 flex flex-col items-start">
           {filteredMenuItems.map((item) => {
@@ -137,23 +122,17 @@ export const Sidebar = ({
         </ul>
       </nav>
 
-      {/* User Info */}
       <div className="p-4 border-t border-border">
         {isOpen ? (
           <div className="space-y-2">
-            <div className="text-sm font-medium text-foreground truncate">
-              {user.name}
-            </div>
-            <div className="text-xs text-muted-foreground capitalize">
-              {user.role}
-              {user.specialty && ` • ${user.specialty}`}
-            </div>
+            <div className="text-sm font-medium text-foreground truncate">{user.name}</div>
+            <div className="text-xs text-muted-foreground capitalize">{user.role}</div>
           </div>
         ) : (
           <div className="flex justify-center">
             <div className="w-8 h-8 bg-gray-800 rounded-full flex items-center justify-center">
               <span className="text-xs font-medium text-foreground">
-                {user.name.charAt(0).toUpperCase()}
+                {(user.name || user.username || "U").charAt(0).toUpperCase()}
               </span>
             </div>
           </div>

--- a/frontend/src/pages/home/Home.jsx
+++ b/frontend/src/pages/home/Home.jsx
@@ -10,15 +10,16 @@ import {
   UserCheck,
 } from "lucide-react";
 import React from "react";
-import { useUser } from "../../context/UserContext";
+import { useUser } from "../../context/UserContext.jsx";
 import { useNavigate } from "react-router";
 
 export const Home = () => {
   const navigate = useNavigate();
   const { user } = useUser();
+  const role = user?.role ?? "assistant";
 
   const getDashboardCards = () => {
-    switch (user.role) {
+    switch (role) {
       case "doctor":
         return [
           {
@@ -97,7 +98,7 @@ export const Home = () => {
   };
 
   const getQuickActions = () => {
-    switch (user.role) {
+    switch (role) {
       case "doctor":
         return [
           {

--- a/frontend/src/pages/login/Login.jsx
+++ b/frontend/src/pages/login/Login.jsx
@@ -1,38 +1,32 @@
 import React, { useState } from "react";
-import { Card, Input, Button, Select } from "antd";
-import { Link } from "react-router-dom";
-import { Stethoscope, Shield, UserCheck } from "lucide-react";
+import { Card, Input, Button, message } from "antd";
+import { Link, Navigate, useNavigate } from "react-router-dom";
+import { Stethoscope } from "lucide-react";
+import { useUser } from "../../context/UserContext.jsx";
 
-const { Option } = Select;
-const LoginForm = ({ onLogin }) => {
-  const [email, setEmail] = useState("");
+const LoginForm = () => {
+  const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
-  const [role, setRole] = useState("");
-  const [loading, setLoading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const navigate = useNavigate();
+  const { login, isAuthenticated } = useUser();
 
-  const handleSubmit = (e) => {
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    setLoading(true);
-
-    // Simulate API call
-    setTimeout(() => {
-      const user = {
-        id: "1",
-        name:
-          role === "doctor"
-            ? "Dr. Sarah Johnson"
-            : role === "transcriptionist"
-            ? "Alice Smith"
-            : "Admin User",
-        email,
-        role,
-        specialty: role === "doctor" ? "Cardiology" : undefined,
-      };
-
-      localStorage.setItem("user", JSON.stringify(user));
-      onLogin?.(user);
-      setLoading(false);
-    }, 1000);
+    setSubmitting(true);
+    try {
+      await login(username, password);
+      message.success("Logged in successfully");
+      navigate("/dashboard");
+    } catch (error) {
+      message.error(error?.message ?? "Unable to login");
+    } finally {
+      setSubmitting(false);
+    }
   };
 
   return (
@@ -44,36 +38,27 @@ const LoginForm = ({ onLogin }) => {
               <Stethoscope className="w-6 h-6 text-white" />
             </div>
             <h2 className="text-xl font-bold">MedTranscribe</h2>
-            <p className="text-sm text-gray-500">
-              Secure Medical Transcription Platform
-            </p>
+            <p className="text-sm text-gray-500">Secure Medical Transcription Platform</p>
           </div>
         }
         className="w-full max-w-md"
       >
         <form onSubmit={handleSubmit} className="space-y-4">
           <div className="space-y-1">
-            <label
-              htmlFor="email"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Email
+            <label htmlFor="username" className="block text-sm font-medium text-gray-700">
+              Username
             </label>
             <Input
-              id="email"
-              type="email"
+              id="username"
               placeholder="doctor@hospital.com"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
               required
             />
           </div>
 
           <div className="space-y-1">
-            <label
-              htmlFor="password"
-              className="block text-sm font-medium text-gray-700"
-            >
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
               Password
             </label>
             <Input.Password
@@ -85,78 +70,26 @@ const LoginForm = ({ onLogin }) => {
             />
           </div>
 
-          <div className="space-y-1">
-            <label
-              htmlFor="role"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Role
-            </label>
-            <Select
-              placeholder="Select your role"
-              value={role || undefined}
-              onChange={(value) => setRole(value)}
-              className="w-full"
-            >
-              <Option value="doctor">
-                <div className="flex items-center gap-2">
-                  <Stethoscope className="w-4 h-4" />
-                  Doctor / Clinician
-                </div>
-              </Option>
-              <Option value="transcriptionist">
-                <div className="flex items-center gap-2">
-                  <UserCheck className="w-4 h-4" />
-                  Medical Transcriptionist
-                </div>
-              </Option>
-              <Option value="admin">
-                <div className="flex items-center gap-2">
-                  <Shield className="w-4 h-4" />
-                  Administrator
-                </div>
-              </Option>
-            </Select>
-          </div>
-
-          <Button
-            type="primary"
-            htmlType="submit"
-            className="w-full"
-            loading={loading}
-          >
+          <Button type="primary" htmlType="submit" className="w-full" loading={submitting}>
             Sign In
           </Button>
-         <div className="flex flex-col items-center gap-2 text-sm text-gray-600">
+          <div className="flex flex-col items-center gap-2 text-sm text-gray-600">
             <p>
               Forgot my password?{" "}
-              <Link
-                to="/forgot-password"
-                className="font-medium text-blue-600 hover:text-blue-500"
-              >
+              <Link to="/forgot-password" className="font-medium text-blue-600 hover:text-blue-500">
                 Reset password
               </Link>
             </p>
             <p>
               Don&apos;t have an account?{" "}
-              <Link
-                to="/signup"
-                className="font-medium text-blue-600 hover:text-blue-500"
-              >
+              <Link to="/signup" className="font-medium text-blue-600 hover:text-blue-500">
                 Sign up
               </Link>
             </p>
           </div>
-
         </form>
-
-        {/* <div className="mt-4 text-center text-sm text-gray-600">
-          <p>Demo Credentials:</p>
-          <p>Email: demo@medtranscribe.com</p>
-          <p>Password: demo123</p>
-        </div> */}
       </Card>
     </div>
   );
-}
+};
 export default LoginForm;

--- a/frontend/src/pages/settings/Settings.jsx
+++ b/frontend/src/pages/settings/Settings.jsx
@@ -21,7 +21,7 @@ import React, { useState } from "react";
 import { useTheme } from "../../context/ThemeContext";
 import PhoneInput from "react-phone-input-2";
 import PhoneNumberInput from "../../components/phoneNumberInput/PhoneNumberInput";
-import { useUser } from "../../context/UserContext";
+import { useUser } from "../../context/UserContext.jsx";
 
 const { Option } = Select;
 
@@ -47,63 +47,56 @@ export const Settings = () => {
     console.log("Phone:", fullNumber);
   };
 
-  const ProfileCard = () => (
-    <Card
-      title="Profile Information"
-      extra={<User className="w-5 h-5" />}
-    >
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-2">
-        <Input
-          placeholder="First Name"
-          defaultValue={user.name.split(" ")[0]}
-        />
-        <Input
-          placeholder="Last Name"
-          defaultValue={user.name.split(" ").slice(1).join(" ")}
-        />
-      </div>
-      <div className="mb-2">
-        <Input
-          className="mb-2"
-          placeholder="Email Address"
-          defaultValue={user.email}
-        />
-      </div>
+  const ProfileCard = () => {
+    const fullName = user?.name ?? user?.username ?? "";
+    const [firstName, ...rest] = fullName.split(" ");
+    const lastName = rest.join(" ");
 
-      <div className="mb-2">
-        {user.role === "doctor" && (
-          <ConfigProvider
-            theme={{
-              token: {
-                colorBgContainer: theme === "dark" ? "#1f1f1f" : "#ffffff",
-                colorText: theme === "dark" ? "#ffffff" : "#0a0a0a",
+    return (
+      <Card title="Profile Information" extra={<User className="w-5 h-5" />}>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-2">
+          <Input placeholder="First Name" defaultValue={firstName} />
+          <Input placeholder="Last Name" defaultValue={lastName} />
+        </div>
+        <div className="mb-2">
+          <Input
+            className="mb-2"
+            placeholder="Username"
+            defaultValue={user?.username}
+          />
+        </div>
 
-                optionSelectedBg: theme === "dark" ? "#bfbfbf" : "#000000",
-                selectorBg: theme === "dark" ? "#1f1f1f" : "#ffffff",
-                optionSelectedColor: theme === "dark" ? "#0a0a0a" : "#ffffff",
-                optionActiveBg: theme === "dark" ? "#bfbfbf" : "#bfbfbf",
-                colorBgElevated: theme === "dark" ? "#1f1f1f" : "#ffffff",
-              },
-            }}
-          >
-            <Select
-              defaultValue={user.specialty?.toLowerCase()}
-              className="mt-4 w-full"
+        <div className="mb-2">
+          {user?.role === "doctor" && (
+            <ConfigProvider
+              theme={{
+                token: {
+                  colorBgContainer: theme === "dark" ? "#1f1f1f" : "#ffffff",
+                  colorText: theme === "dark" ? "#ffffff" : "#0a0a0a",
+                  optionSelectedBg: theme === "dark" ? "#bfbfbf" : "#000000",
+                  selectorBg: theme === "dark" ? "#1f1f1f" : "#ffffff",
+                  optionSelectedColor: theme === "dark" ? "#0a0a0a" : "#ffffff",
+                  optionActiveBg: theme === "dark" ? "#bfbfbf" : "#bfbfbf",
+                  colorBgElevated: theme === "dark" ? "#1f1f1f" : "#ffffff",
+                },
+              }}
             >
-              <Option value="cardiology">Cardiology</Option>
-              <Option value="neurology">Neurology</Option>
-              <Option value="orthopedics">Orthopedics</Option>
-              <Option value="internal-medicine">Internal Medicine</Option>
-              <Option value="pediatrics">Pediatrics</Option>
-              <Option value="surgery">Surgery</Option>
-            </Select>
-          </ConfigProvider>
-        )}
-      </div>
+              <Select defaultValue={user?.specialty?.toLowerCase()} className="mt-4 w-full">
+                <Option value="cardiology">Cardiology</Option>
+                <Option value="neurology">Neurology</Option>
+                <Option value="orthopedics">Orthopedics</Option>
+                <Option value="internal-medicine">Internal Medicine</Option>
+                <Option value="pediatrics">Pediatrics</Option>
+                <Option value="surgery">Surgery</Option>
+              </Select>
+            </ConfigProvider>
+          )}
+        </div>
 
-      <PhoneNumberInput onChange={handlePhoneChange} />
-    </Card>
-  );
+        <PhoneNumberInput onChange={handlePhoneChange} />
+      </Card>
+    );
+  };
 
   const SecurityCard = () => (
     <Card title="Password & Security" extra={<Lock className="w-5 h-5" />}>

--- a/frontend/src/pages/signup/Signup.jsx
+++ b/frontend/src/pages/signup/Signup.jsx
@@ -1,47 +1,45 @@
 import React, { useState } from "react";
-import { Card, Input, Button, Select } from "antd";
-import { Link } from "react-router-dom";
-import {
-  Mail,
-  Lock,
-  Stethoscope,
-  UserCheck,
-  Shield,
-} from "lucide-react";
+import { Card, Input, Button, Select, message } from "antd";
+import { Link, Navigate, useNavigate } from "react-router-dom";
+import { Mail, Lock, Stethoscope, UserCheck, Shield } from "lucide-react";
+import { useUser } from "../../context/UserContext.jsx";
 
 const { Option } = Select;
 
-const SignupForm = ({ onSignup }) => {
-  const [name, setName] = useState("");
+const SignupForm = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [role, setRole] = useState("");
   const [loading, setLoading] = useState(false);
+  const { register, isAuthenticated } = useUser();
+  const navigate = useNavigate();
 
-  const handleSignup = (e) => {
+  if (isAuthenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  const handleSignup = async (e) => {
     e.preventDefault();
-    setLoading(true);
-
     if (password !== confirmPassword) {
-      alert("Passwords do not match");
-      setLoading(false);
+      message.error("Passwords do not match");
+      return;
+    }
+    if (!role) {
+      message.error("Please select a role");
       return;
     }
 
-    setTimeout(() => {
-      const newUser = {
-        id: Date.now().toString(),
-        name,
-        email,
-        role,
-        specialty: role === "doctor" ? "General Medicine" : undefined,
-      };
-
-      localStorage.setItem("user", JSON.stringify(newUser));
-      onSignup(newUser);
+    setLoading(true);
+    try {
+      await register({ username: email, password, role });
+      message.success("Account created successfully");
+      navigate("/dashboard");
+    } catch (error) {
+      message.error(error?.message ?? "Unable to sign up");
+    } finally {
       setLoading(false);
-    }, 1000);
+    }
   };
 
   return (
@@ -60,28 +58,8 @@ const SignupForm = ({ onSignup }) => {
       >
         <form onSubmit={handleSignup} className="space-y-4">
           <div className="space-y-1">
-            <label
-              htmlFor="name"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Full Name
-            </label>
-            <Input
-              id="name"
-              prefix={<UserCheck size={16} />}
-              placeholder="Dr. Jane Doe"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-            />
-          </div>
-
-          <div className="space-y-1">
-            <label
-              htmlFor="email"
-              className="block text-sm font-medium text-gray-700"
-            >
-              Email
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              Username or Email
             </label>
             <Input
               id="email"
@@ -95,10 +73,7 @@ const SignupForm = ({ onSignup }) => {
           </div>
 
           <div className="space-y-1">
-            <label
-              htmlFor="password"
-              className="block text-sm font-medium text-gray-700"
-            >
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
               Password
             </label>
             <Input.Password
@@ -112,10 +87,7 @@ const SignupForm = ({ onSignup }) => {
           </div>
 
           <div className="space-y-1">
-            <label
-              htmlFor="confirmPassword"
-              className="block text-sm font-medium text-gray-700"
-            >
+            <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">
               Confirm Password
             </label>
             <Input.Password
@@ -129,10 +101,7 @@ const SignupForm = ({ onSignup }) => {
           </div>
 
           <div className="space-y-1">
-            <label
-              htmlFor="role"
-              className="block text-sm font-medium text-gray-700"
-            >
+            <label htmlFor="role" className="block text-sm font-medium text-gray-700">
               Role
             </label>
             <Select
@@ -143,39 +112,28 @@ const SignupForm = ({ onSignup }) => {
             >
               <Option value="doctor">
                 <div className="flex items-center gap-2">
-                  <Stethoscope className="w-4 h-4" />
-                  Doctor / Clinician
+                  <Stethoscope className="w-4 h-4" /> Doctor / Clinician
                 </div>
               </Option>
               <Option value="transcriptionist">
                 <div className="flex items-center gap-2">
-                  <UserCheck className="w-4 h-4" />
-                  Medical Transcriptionist
+                  <UserCheck className="w-4 h-4" /> Medical Transcriptionist
                 </div>
               </Option>
               <Option value="admin">
                 <div className="flex items-center gap-2">
-                  <Shield className="w-4 h-4" />
-                  Administrator
+                  <Shield className="w-4 h-4" /> Administrator
                 </div>
               </Option>
             </Select>
           </div>
 
-          <Button
-            type="primary"
-            htmlType="submit"
-            className="w-full"
-            loading={loading}
-          >
+          <Button type="primary" htmlType="submit" className="w-full" loading={loading}>
             Sign Up
           </Button>
           <p className="text-center text-sm text-gray-600">
             Already have an account?{" "}
-            <Link
-              to="/login"
-              className="font-medium text-blue-600 hover:text-blue-500"
-            >
+            <Link to="/login" className="font-medium text-blue-600 hover:text-blue-500">
               Log In
             </Link>
           </p>

--- a/frontend/src/routes/Routerset.jsx
+++ b/frontend/src/routes/Routerset.jsx
@@ -1,33 +1,58 @@
-import React from 'react'
-import { Routes, Route } from "react-router-dom";
+import React from "react";
+import { Routes, Route, Navigate } from "react-router-dom";
+import { Spin } from "antd";
 import LoginForm from "../pages/login/Login.jsx";
 import SignupForm from "../pages/signup/Signup.jsx";
 import LandingPage from "../pages/landingPage/LandingPage.jsx";
-import DashboardLayout from "../layout/DashboardLayout.jsx"
-import { Home } from '../pages/home/Home.jsx';
-import { NewTranscription } from '../pages/newtranscription/NewTranscription.jsx';
-import { History } from '../pages/history/History.jsx';
-import { Review } from '../pages/review/Review.jsx';
-import { Admin } from '../pages/admin/Admin.jsx';
-import { Settings } from '../pages/settings/Settings.jsx';
-import ResetPassword from '../pages/resetPassword/ResetPassword.jsx';
+import DashboardLayout from "../layout/DashboardLayout.jsx";
+import { Home } from "../pages/home/Home.jsx";
+import { NewTranscription } from "../pages/newtranscription/NewTranscription.jsx";
+import { History } from "../pages/history/History.jsx";
+import { Review } from "../pages/review/Review.jsx";
+import { Admin } from "../pages/admin/Admin.jsx";
+import { Settings } from "../pages/settings/Settings.jsx";
+import ResetPassword from "../pages/resetPassword/ResetPassword.jsx";
+import { useUser } from "../context/UserContext.jsx";
 
-export const Routerset = () => {
-  return (
-    <Routes>
-      <Route path="/login" element={<LoginForm />} />
-      <Route path="/signup" element={<SignupForm />} />
-      <Route path="/forgot-password" element={<ResetPassword />} />
-      <Route path="/" element={<LandingPage />} />
-      {/* <Route path="/dashboard" element={<Dashboard />} /> */}
-      <Route path="/dashboard" element={<DashboardLayout />}>
-        <Route index element={<Home />} /> {/* default dashboard page */}
-        <Route path="new-transcription" element={<NewTranscription />} />
-        <Route path="history" element={<History/>} />
-        <Route path="review" element={<Review />} />
-        <Route path="admin" element={<Admin/>} />
-        <Route path="settings" element={<Settings />} />
-      </Route>
-    </Routes>
-  );
+const ProtectedRoute = ({ children }) => {
+  const { isAuthenticated, loading } = useUser();
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Spin size="large" />
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return children;
 };
+
+export const Routerset = () => (
+  <Routes>
+    <Route path="/login" element={<LoginForm />} />
+    <Route path="/signup" element={<SignupForm />} />
+    <Route path="/forgot-password" element={<ResetPassword />} />
+    <Route path="/" element={<LandingPage />} />
+    <Route
+      path="/dashboard"
+      element={(
+        <ProtectedRoute>
+          <DashboardLayout />
+        </ProtectedRoute>
+      )}
+    >
+      <Route index element={<Home />} />
+      <Route path="new-transcription" element={<NewTranscription />} />
+      <Route path="history" element={<History />} />
+      <Route path="review" element={<Review />} />
+      <Route path="admin" element={<Admin />} />
+      <Route path="settings" element={<Settings />} />
+    </Route>
+    <Route path="*" element={<Navigate to="/" replace />} />
+  </Routes>
+);


### PR DESCRIPTION
## Summary
- allow configuring more than one frontend origin by parsing the FRONTEND_ORIGIN setting as a comma-separated list
- default to supporting both localhost:3000 and localhost:5173 so local Vite builds can access the API
- wire the FastAPI CORS middleware to the parsed origin list

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_690cf10c1f00832e9033c8a2baea42bc