### PR TITLE
Implement secure JWT auth with refresh tokens

### DIFF
--- a/backend/app/api/v1/routes_auth.py
+++ b/backend/app/api/v1/routes_auth.py
@@ -1,5 +1,4 @@
-from fastapi import APIRouter, Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordRequestForm
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from sqlalchemy.orm import Session
 
 from app.infra.db import get_db
@@ -28,17 +27,26 @@ def register(
     return schemas.UserRead.from_orm(user)
 
 
-@router.post("/token", response_model=schemas.Token)
+@router.post("/login", response_model=schemas.Token)
 def login(
-    form_data: OAuth2PasswordRequestForm = Depends(),
+    payload: schemas.LoginRequest,
+    response: Response = None,
     db: Session = Depends(get_db),
 ) -> schemas.Token:
+    response = response or Response()
     user_repo = repositories.UserRepository(db)
-    user = user_repo.get_by_username(form_data.username)
-    if not user or not auth.verify_password(form_data.password, user.hashed_password):
+    username = getattr(payload, "username", None)
+    password = getattr(payload, "password", None)
+    if not username or not password:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing credentials")
+
+    user = user_repo.get_by_username(username)
+    if not user or not auth.verify_password(password, user.hashed_password):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
 
     access_token = auth.create_access_token(subject=user.id)
+    refresh_token = auth.create_refresh_token(subject=user.id)
+    auth.set_refresh_cookie(response, refresh_token)
     return schemas.Token(access_token=access_token)
 
 
@@ -47,7 +55,38 @@ def me(current_user=Depends(auth.get_current_user)) -> schemas.UserRead:
     return schemas.UserRead.from_orm(current_user)
 
 
-@router.post("/logout")
-def logout():
-    raise HTTPException(status_code=status.HTTP_501_NOT_IMPLEMENTED, detail="TODO: Implement logout")
+@router.post("/refresh", response_model=schemas.Token)
+def refresh(
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+) -> schemas.Token:
+    refresh_cookie = request.cookies.get(auth.settings.REFRESH_TOKEN_COOKIE_NAME)
+    if not refresh_cookie:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+
+    payload = auth.decode_refresh_token(refresh_cookie)
+    user_repo = repositories.UserRepository(db)
+    user = user_repo.get(payload.sub)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Could not validate credentials")
+
+    new_access_token = auth.create_access_token(subject=user.id)
+    new_refresh_token = auth.create_refresh_token(subject=user.id)
+    auth.set_refresh_cookie(response, new_refresh_token)
+    return schemas.Token(access_token=new_access_token)
+
+
+@router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
+def logout(response: Response) -> Response:
+    auth.clear_refresh_cookie(response)
+    return response
+
+
+@router.get("/protected")
+def protected_route(current_user=Depends(auth.get_current_user)) -> dict[str, object]:
+    return {
+        "message": "Authenticated request successful",
+        "user": schemas.UserRead.from_orm(current_user),
+    }
 

--- a/backend/app/domain/schemas.py
+++ b/backend/app/domain/schemas.py
@@ -10,9 +10,15 @@ class Token(BaseModel):
     token_type: str = "bearer"
 
 
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
+
 class TokenPayload(BaseModel):
     sub: int
     exp: int
+    type: str
 
 
 class UserBase(BaseModel):

--- a/backend/app/infra/auth.py
+++ b/backend/app/infra/auth.py
@@ -3,9 +3,10 @@ import hashlib
 import secrets
 from typing import Iterable
 
-from fastapi import Depends, HTTPException, status
-from fastapi.security import OAuth2PasswordBearer
-from jose import JWTError, jwt
+from fastapi import Depends, HTTPException, Response, params, status
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+import jwt
+from jwt import ExpiredSignatureError, InvalidTokenError
 from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 
@@ -18,7 +19,7 @@ from app.settings import get_settings
 settings = get_settings()
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/v1/auth/token")
+security = HTTPBearer(auto_error=False)
 
 FALLBACK_PREFIX = "sha256$"
 
@@ -41,25 +42,115 @@ def verify_password(plain_password: str, hashed_password: str) -> bool:
         return False
 
 
-def create_access_token(*, subject: int, expires_delta: timedelta | None = None) -> str:
-    expire = datetime.utcnow() + (expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES))
-    to_encode = {"exp": expire, "sub": str(subject)}
+def _create_token(*, subject: int, expires_delta: timedelta, token_type: str) -> str:
+    now = datetime.utcnow()
+    expire = now + expires_delta
+    to_encode = {
+        "sub": str(subject),
+        "type": token_type,
+        "iat": now,
+        "exp": expire,
+    }
     return jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.JWT_ALG)
 
 
-def decode_access_token(token: str) -> TokenPayload:
+def create_access_token(*, subject: int, expires_delta: timedelta | None = None) -> str:
+    lifetime = expires_delta or timedelta(minutes=settings.ACCESS_TOKEN_EXPIRE_MINUTES)
+    return _create_token(subject=subject, expires_delta=lifetime, token_type="access")
+
+
+def create_refresh_token(*, subject: int, expires_delta: timedelta | None = None) -> str:
+    lifetime = expires_delta or timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
+    return _create_token(subject=subject, expires_delta=lifetime, token_type="refresh")
+
+
+def _decode_token(token: str, expected_type: str) -> TokenPayload:
     try:
         payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.JWT_ALG])
-        return TokenPayload(sub=int(payload.get("sub")), exp=payload.get("exp"))
-    except (JWTError, ValueError) as exc:
+    except ExpiredSignatureError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Token expired",
+        ) from exc
+    except InvalidTokenError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Could not validate credentials",
         ) from exc
 
+    token_type = payload.get("type")
+    subject = payload.get("sub")
+    exp = payload.get("exp")
 
-def get_current_user(db: Session = Depends(get_db), token: str = Depends(oauth2_scheme)) -> User:
-    payload = decode_access_token(token)
+    if token_type != expected_type:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid token type",
+        )
+
+    try:
+        subject_id = int(subject)
+        exp_value = int(exp)
+    except (TypeError, ValueError) as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Could not validate credentials",
+        ) from exc
+
+    return TokenPayload(sub=subject_id, exp=exp_value, type=token_type)
+
+
+def decode_access_token(token: str) -> TokenPayload:
+    return _decode_token(token, expected_type="access")
+
+
+def decode_refresh_token(token: str) -> TokenPayload:
+    return _decode_token(token, expected_type="refresh")
+
+
+def set_refresh_cookie(response: Response, refresh_token: str) -> None:
+    response.set_cookie(
+        key=settings.REFRESH_TOKEN_COOKIE_NAME,
+        value=refresh_token,
+        httponly=True,
+        secure=settings.REFRESH_COOKIE_SECURE,
+        samesite="strict",
+        max_age=settings.REFRESH_TOKEN_EXPIRE_DAYS * 24 * 60 * 60,
+        path="/",
+    )
+
+
+def clear_refresh_cookie(response: Response) -> None:
+    response.delete_cookie(
+        key=settings.REFRESH_TOKEN_COOKIE_NAME,
+        path="/",
+        httponly=True,
+        secure=settings.REFRESH_COOKIE_SECURE,
+        samesite="strict",
+    )
+
+
+def get_current_user(
+    db: Session = Depends(get_db),
+    credentials: HTTPAuthorizationCredentials | None = Depends(security),
+    token: str | None = None,
+) -> User:
+    raw_token: str | None = None
+    direct_call = isinstance(credentials, params.Depends)
+
+    if token is not None and direct_call:
+        raw_token = token
+
+    if raw_token is None and isinstance(credentials, HTTPAuthorizationCredentials):
+        raw_token = credentials.credentials
+
+    if raw_token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Not authenticated",
+        )
+
+    payload = decode_access_token(raw_token)
     user = repositories.UserRepository(db).get(payload.sub)
     if not user:
         raise HTTPException(
@@ -87,7 +178,11 @@ __all__ = [
     "hash_password",
     "verify_password",
     "create_access_token",
+    "create_refresh_token",
     "decode_access_token",
+    "decode_refresh_token",
+    "set_refresh_cookie",
+    "clear_refresh_cookie",
     "get_current_user",
     "require_roles",
 ]

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -10,7 +10,10 @@ class Settings(BaseSettings):
     ENV: str = Field(default="development")
     SECRET_KEY: str
     JWT_ALG: str = "HS256"
-    ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    ACCESS_TOKEN_EXPIRE_MINUTES: int = 15
+    REFRESH_TOKEN_EXPIRE_DAYS: int = 7
+    REFRESH_TOKEN_COOKIE_NAME: str = "refresh_token"
+    REFRESH_COOKIE_SECURE: bool = True
 
     DATABASE_URL: AnyUrl
     BROKER_URL: AnyUrl

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -12,7 +12,7 @@ fastapi = "^0.109.0"
 uvicorn = {extras = ["standard"], version = "^0.27.0"}
 SQLAlchemy = "^2.0"
 pydantic-settings = "^2.1"
-python-jose = {extras = ["cryptography"], version = "^3.3"}
+PyJWT = {extras = ["crypto"], version = "^2.8"}
 passlib = {extras = ["bcrypt"], version = "^1.7"}
 python-multipart = "^0.0.6"
 redis = "^5.0"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,7 @@ fastapi==0.109.0
 uvicorn[standard]==0.27.0
 sqlalchemy==2.0.25
 pydantic-settings==2.1.0
-python-jose[cryptography]==3.3.0
+PyJWT[crypto]==2.8.0
 passlib[bcrypt]==1.7.4
 python-multipart==0.0.6
 psycopg[binary]==3.1.16

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -26,7 +26,9 @@ const handleResponse = async (response) => {
     } catch (error) {
       // ignore JSON parse errors
     }
-    throw new Error(message || "Request failed");
+    const error = new Error(message || "Request failed");
+    error.status = response.status;
+    throw error;
   }
 
   if (response.status === 204) {
@@ -41,17 +43,26 @@ const handleResponse = async (response) => {
 };
 
 export const login = async (username, password) => {
-  const body = new URLSearchParams();
-  body.append("username", username);
-  body.append("password", password);
-
-  const response = await fetch(`${API_BASE_URL}/v1/auth/token`, {
+  const response = await fetch(`${API_BASE_URL}/v1/auth/login`, {
     method: "POST",
     headers: {
-      "Content-Type": "application/x-www-form-urlencoded",
+      "Content-Type": "application/json",
       Accept: "application/json",
     },
-    body,
+    credentials: "include",
+    body: JSON.stringify({ username, password }),
+  });
+
+  return handleResponse(response);
+};
+
+export const refreshAccessToken = async () => {
+  const response = await fetch(`${API_BASE_URL}/v1/auth/refresh`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+    },
+    credentials: "include",
   });
 
   return handleResponse(response);
@@ -61,6 +72,7 @@ export const register = async ({ username, password, role }) => {
   const response = await fetch(`${API_BASE_URL}/v1/auth/register`, {
     method: "POST",
     headers: buildHeaders(null, { "Content-Type": "application/json" }),
+    credentials: "include",
     body: JSON.stringify({ username, password, role }),
   });
 
@@ -71,6 +83,7 @@ export const getCurrentUser = async (token) => {
   const response = await fetch(`${API_BASE_URL}/v1/auth/me`, {
     method: "GET",
     headers: buildHeaders(token),
+    credentials: "include",
   });
 
   return handleResponse(response);
@@ -80,6 +93,7 @@ export const listJobs = async (token) => {
   const response = await fetch(`${API_BASE_URL}/v1/jobs`, {
     method: "GET",
     headers: buildHeaders(token),
+    credentials: "include",
   });
 
   return handleResponse(response);
@@ -89,6 +103,7 @@ export const createJob = async (token, payload) => {
   const response = await fetch(`${API_BASE_URL}/v1/jobs`, {
     method: "POST",
     headers: buildHeaders(token, { "Content-Type": "application/json" }),
+    credentials: "include",
     body: JSON.stringify(payload),
   });
 
@@ -102,7 +117,20 @@ export const uploadTranscription = async (token, file) => {
   const response = await fetch(`${API_BASE_URL}/v1/transcribe/upload`, {
     method: "POST",
     headers: buildHeaders(token),
+    credentials: "include",
     body: formData,
+  });
+
+  return handleResponse(response);
+};
+
+export const logout = async () => {
+  const response = await fetch(`${API_BASE_URL}/v1/auth/logout`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+    },
+    credentials: "include",
   });
 
   return handleResponse(response);

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -1,8 +1,15 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import * as api from "../api/client";
 
 const UserContext = createContext();
-const TOKEN_STORAGE_KEY = "medtranscribe_access_token";
 
 const normalizeUser = (user) => ({
   id: user.id,
@@ -15,51 +22,104 @@ const normalizeUser = (user) => ({
 
 export const UserProvider = ({ children }) => {
   const [user, setUser] = useState(null);
-  const [token, setToken] = useState(() => localStorage.getItem(TOKEN_STORAGE_KEY));
-  const [loading, setLoading] = useState(Boolean(localStorage.getItem(TOKEN_STORAGE_KEY)));
-  const skipAutoFetch = useRef(false);
+  const [accessToken, setAccessToken] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const refreshPromiseRef = useRef(null);
 
-  const loadUser = useCallback(
-    async (authToken) => {
-      const profile = await api.getCurrentUser(authToken);
-      const normalized = normalizeUser(profile);
-      setUser(normalized);
-      return normalized;
+  const clearSession = useCallback(() => {
+    setAccessToken(null);
+    setUser(null);
+  }, []);
+
+  const fetchCurrentUser = useCallback(async (token) => {
+    const profile = await api.getCurrentUser(token);
+    const normalized = normalizeUser(profile);
+    setUser(normalized);
+    return normalized;
+  }, []);
+
+  const refreshAccessToken = useCallback(async () => {
+    if (refreshPromiseRef.current) {
+      return refreshPromiseRef.current;
+    }
+
+    const refreshTask = (async () => {
+      try {
+        const response = await api.refreshAccessToken();
+        if (response?.access_token) {
+          setAccessToken(response.access_token);
+          return response.access_token;
+        }
+        clearSession();
+        return null;
+      } catch (error) {
+        if (error?.status === 401) {
+          clearSession();
+          return null;
+        }
+        throw error;
+      } finally {
+        refreshPromiseRef.current = null;
+      }
+    })();
+
+    refreshPromiseRef.current = refreshTask;
+    return refreshTask;
+  }, [clearSession]);
+
+  const callWithAuth = useCallback(
+    async (fn, ...args) => {
+      let tokenToUse = accessToken;
+
+      if (!tokenToUse) {
+        tokenToUse = await refreshAccessToken();
+        if (!tokenToUse) {
+          throw Object.assign(new Error("Authentication required"), { status: 401 });
+        }
+      }
+
+      try {
+        return await fn(tokenToUse, ...args);
+      } catch (error) {
+        if (error?.status === 401) {
+          const refreshed = await refreshAccessToken();
+          if (!refreshed) {
+            clearSession();
+            throw error;
+          }
+          try {
+            return await fn(refreshed, ...args);
+          } catch (retryError) {
+            if (retryError?.status === 401) {
+              clearSession();
+            }
+            throw retryError;
+          }
+        }
+        throw error;
+      }
     },
-    []
+    [accessToken, refreshAccessToken, clearSession]
   );
 
   useEffect(() => {
     let active = true;
 
-    if (!token) {
-      setUser(null);
-      setLoading(false);
-      return undefined;
-    }
-
-    if (skipAutoFetch.current) {
-      skipAutoFetch.current = false;
-      return undefined;
-    }
-
-    if (user) {
-      setLoading(false);
-      return undefined;
-    }
-
-    setLoading(true);
     (async () => {
       try {
-        await loadUser(token);
+        const tokenFromRefresh = await refreshAccessToken();
+        if (!active || !tokenFromRefresh) {
+          return;
+        }
+        await fetchCurrentUser(tokenFromRefresh);
       } catch (error) {
         if (!active) {
           return;
         }
-        console.error("Failed to load current user", error);
-        localStorage.removeItem(TOKEN_STORAGE_KEY);
-        setToken(null);
-        setUser(null);
+        if (error?.status !== 401) {
+          console.error("Failed to restore session", error);
+        }
+        clearSession();
       } finally {
         if (active) {
           setLoading(false);
@@ -70,28 +130,27 @@ export const UserProvider = ({ children }) => {
     return () => {
       active = false;
     };
-  }, [token, user, loadUser]);
+  }, [refreshAccessToken, fetchCurrentUser, clearSession]);
 
   const login = useCallback(
     async (username, password) => {
       setLoading(true);
       try {
         const authResponse = await api.login(username, password);
-        skipAutoFetch.current = true;
-        localStorage.setItem(TOKEN_STORAGE_KEY, authResponse.access_token);
-        setToken(authResponse.access_token);
-        await loadUser(authResponse.access_token);
+        if (!authResponse?.access_token) {
+          throw new Error("No access token returned by server");
+        }
+        setAccessToken(authResponse.access_token);
+        await fetchCurrentUser(authResponse.access_token);
         return authResponse;
       } catch (error) {
-        localStorage.removeItem(TOKEN_STORAGE_KEY);
-        setToken(null);
-        setUser(null);
+        clearSession();
         throw error;
       } finally {
         setLoading(false);
       }
     },
-    [loadUser]
+    [fetchCurrentUser, clearSession]
   );
 
   const register = useCallback(
@@ -102,32 +161,39 @@ export const UserProvider = ({ children }) => {
     [login]
   );
 
-  const logout = useCallback(() => {
-    localStorage.removeItem(TOKEN_STORAGE_KEY);
-    setToken(null);
-    setUser(null);
-  }, []);
+  const logout = useCallback(async () => {
+    try {
+      await api.logout();
+    } finally {
+      clearSession();
+    }
+  }, [clearSession]);
 
   const refreshUser = useCallback(async () => {
-    if (!token) {
-      return null;
+    try {
+      return await callWithAuth(fetchCurrentUser);
+    } catch (error) {
+      if (error?.status === 401) {
+        clearSession();
+      }
+      throw error;
     }
-    const profile = await loadUser(token);
-    return profile;
-  }, [token, loadUser]);
+  }, [callWithAuth, fetchCurrentUser, clearSession]);
 
   const value = useMemo(
     () => ({
       user,
-      token,
+      token: accessToken,
+      accessToken,
       loading,
       login,
       register,
       logout,
       refreshUser,
-      isAuthenticated: Boolean(user && token),
+      callWithAuth,
+      isAuthenticated: Boolean(user && accessToken),
     }),
-    [user, token, loading, login, register, logout, refreshUser]
+    [user, accessToken, loading, login, register, logout, refreshUser, callWithAuth]
   );
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;

--- a/frontend/src/pages/history/History.jsx
+++ b/frontend/src/pages/history/History.jsx
@@ -7,22 +7,22 @@ import { listJobs } from "../../api/client";
 export const History = () => {
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(false);
-  const { token } = useUser();
+  const { callWithAuth, isAuthenticated } = useUser();
 
   const fetchJobs = useCallback(async () => {
-    if (!token) {
+    if (!isAuthenticated) {
       return;
     }
     setLoading(true);
     try {
-      const response = await listJobs(token);
+      const response = await callWithAuth(listJobs);
       setJobs(Array.isArray(response) ? response : []);
     } catch (error) {
       message.error(error?.message ?? "Unable to load jobs");
     } finally {
       setLoading(false);
     }
-  }, [token]);
+  }, [callWithAuth, isAuthenticated]);
 
   useEffect(() => {
     fetchJobs();

--- a/frontend/src/pages/newtranscription/NewTranscription.jsx
+++ b/frontend/src/pages/newtranscription/NewTranscription.jsx
@@ -45,7 +45,7 @@ export const NewTranscription = () => {
   const [uploading, setUploading] = useState(false);
 
   const { theme } = useTheme();
-  const { token } = useUser();
+  const { callWithAuth, isAuthenticated } = useUser();
 
   const intervalRef = useRef();
   const textareaRef = useRef(null);
@@ -148,7 +148,7 @@ export const NewTranscription = () => {
   };
 
   const finalizeTranscription = async () => {
-    if (!token) {
+    if (!isAuthenticated) {
       message.error("You must be logged in to submit audio");
       return;
     }
@@ -160,10 +160,10 @@ export const NewTranscription = () => {
 
     setUploading(true);
     try {
-      const uploadResponse = await uploadTranscription(token, audioFile);
+      const uploadResponse = await callWithAuth(uploadTranscription, audioFile);
       message.success(uploadResponse?.detail ?? "Audio uploaded successfully");
 
-      await createJob(token, {
+      await callWithAuth(createJob, {
         type: "transcription",
         input_uri: uploadResponse?.filename ?? audioFile.name,
       });


### PR DESCRIPTION
## Summary
- add access/refresh token handling with HttpOnly refresh cookie and refreshed auth routes in FastAPI
- switch backend JWT utilities to PyJWT with refresh decoding helpers and updated security settings
- refactor React auth context and API client to keep the access token in memory, refresh on 401s, and call APIs with credentials

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690d07bde800832eaf6553765d83ce16