### PR TITLE
Ensure logout clears refresh token cookie

### DIFF
--- a/backend/app/api/v1/routes_auth.py
+++ b/backend/app/api/v1/routes_auth.py
@@ -78,7 +78,8 @@ def refresh(
 
 
 @router.post("/logout", status_code=status.HTTP_204_NO_CONTENT)
-def logout(response: Response) -> Response:
+def logout() -> Response:
+    response = Response(status_code=status.HTTP_204_NO_CONTENT)
     auth.clear_refresh_cookie(response)
     return response
 

--- a/backend/app/infra/auth.py
+++ b/backend/app/infra/auth.py
@@ -127,6 +127,8 @@ def clear_refresh_cookie(response: Response) -> None:
         httponly=True,
         secure=settings.REFRESH_COOKIE_SECURE,
         samesite="strict",
+        expires=0,
+        max_age=0,
     )
 
 


### PR DESCRIPTION
## Summary
- return an explicit response from the logout endpoint so the refresh cookie clearing headers are always applied
- force the refresh cookie deletion to include max-age and expires hints to ensure browsers immediately discard it

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_b_690d1aa6d014832ea7254be491638294