### PR TITLE
Fix header dropdown navigation and add profile page

### DIFF
--- a/frontend/src/layout/Header.jsx
+++ b/frontend/src/layout/Header.jsx
@@ -1,9 +1,11 @@
 import { Button, ConfigProvider, Dropdown, Switch, message } from "antd";
 import { User, Settings, LogOut, Moon, Sun } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 import { useTheme } from "../context/ThemeContext.jsx";
 
 export const Header = ({ onLogout, user }) => {
   const { theme, toggleTheme } = useTheme();
+  const navigate = useNavigate();
 
   const handleLogout = async () => {
     try {
@@ -19,7 +21,7 @@ export const Header = ({ onLogout, user }) => {
     {
       key: "profile",
       label: (
-        <div className="flex items-center gap-2 ">
+        <div className="flex items-center gap-2">
           <User className="w-4 h-4 mr-2" />
           Profile
         </div>
@@ -38,12 +40,20 @@ export const Header = ({ onLogout, user }) => {
     {
       key: "theme",
       label: (
-        <div className="flex items-center justify-between gap-2 w-full">
+        <div
+          className="flex items-center justify-between gap-2 w-full"
+          onClick={(event) => event.stopPropagation()}
+        >
           <div className="flex items-center gap-2">
             {theme === "dark" ? <Moon className="w-4 h-4" /> : <Sun className="w-4 h-4" />}
             <span>Dark Mode</span>
           </div>
-          <Switch size="small" checked={theme === "dark"} onChange={toggleTheme} />
+          <Switch
+            size="small"
+            checked={theme === "dark"}
+            onChange={toggleTheme}
+            onClick={(checked, event) => event.stopPropagation()}
+          />
         </div>
       ),
     },
@@ -53,13 +63,29 @@ export const Header = ({ onLogout, user }) => {
     {
       key: "logout",
       label: (
-        <div className="flex items-center gap-2" onClick={handleLogout}>
+        <div className="flex items-center gap-2">
           <LogOut className="w-4 h-4 mr-2" />
           Sign out
         </div>
       ),
     },
   ];
+
+  const handleMenuClick = ({ key }) => {
+    switch (key) {
+      case "profile":
+        navigate("/dashboard/profile");
+        break;
+      case "settings":
+        navigate("/dashboard/settings");
+        break;
+      case "logout":
+        handleLogout();
+        break;
+      default:
+        break;
+    }
+  };
 
   return (
     <header className="bg-background border-b border-border px-1 md:px-6 py-2 md:py-4">
@@ -92,7 +118,11 @@ export const Header = ({ onLogout, user }) => {
             },
           }}
         >
-          <Dropdown menu={{ items: menuItems }} placement="bottomRight" trigger={["click"]}>
+          <Dropdown
+            menu={{ items: menuItems, onClick: handleMenuClick }}
+            placement="bottomRight"
+            trigger={["click"]}
+          >
             <Button type="text" className="flex items-center gap-2">
               <div className="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center">
                 <User className="w-4 h-4 text-white" />

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -1,0 +1,70 @@
+import { Card, Avatar, Descriptions, Tag, Divider } from "antd";
+import { User, Mail, Phone, BriefcaseMedical } from "lucide-react";
+import React from "react";
+import { useUser } from "../../context/UserContext.jsx";
+
+const getInitials = (name = "") =>
+  name
+    .split(" ")
+    .filter(Boolean)
+    .map((part) => part[0]?.toUpperCase())
+    .join("")
+    .slice(0, 2);
+
+export const Profile = () => {
+  const { user } = useUser();
+
+  const displayName = user?.name ?? user?.username ?? "User";
+  const initials = getInitials(displayName);
+  const email = user?.email ?? "Not provided";
+  const phone = user?.phone ?? "Not provided";
+  const role = user?.role ?? "Member";
+  const specialty = user?.specialty ?? "General";
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <Card className="text-center">
+        <Avatar
+          size={96}
+          className="mx-auto mb-4 bg-blue-500"
+          icon={initials ? undefined : <User />}
+        >
+          {initials}
+        </Avatar>
+        <h2 className="text-2xl font-semibold text-foreground">{displayName}</h2>
+        <p className="text-muted-foreground capitalize">{role}</p>
+      </Card>
+
+      <Card title="Contact Information" bordered={false}>
+        <Descriptions column={1} colon={false}>
+          <Descriptions.Item label={<Mail className="w-4 h-4" />}>
+            <span className="ml-2">{email}</span>
+          </Descriptions.Item>
+          <Descriptions.Item label={<Phone className="w-4 h-4" />}>
+            <span className="ml-2">{phone}</span>
+          </Descriptions.Item>
+        </Descriptions>
+      </Card>
+
+      <Card title="Professional Details" bordered={false}>
+        <div className="flex flex-wrap items-center gap-2">
+          <Tag color="blue" className="flex items-center gap-2">
+            <BriefcaseMedical className="w-4 h-4" />
+            <span>{specialty}</span>
+          </Tag>
+          <Tag color="default" className="capitalize">
+            {role}
+          </Tag>
+        </div>
+        {user?.bio && (
+          <>
+            <Divider />
+            <p className="text-muted-foreground whitespace-pre-wrap">{user.bio}</p>
+          </>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default Profile;

--- a/frontend/src/routes/Routerset.jsx
+++ b/frontend/src/routes/Routerset.jsx
@@ -11,6 +11,7 @@ import { History } from "../pages/history/History.jsx";
 import { Review } from "../pages/review/Review.jsx";
 import { Admin } from "../pages/admin/Admin.jsx";
 import { Settings } from "../pages/settings/Settings.jsx";
+import { Profile } from "../pages/profile/Profile.jsx";
 import ResetPassword from "../pages/resetPassword/ResetPassword.jsx";
 import { useUser } from "../context/UserContext.jsx";
 
@@ -51,6 +52,7 @@ export const Routerset = () => (
       <Route path="history" element={<History />} />
       <Route path="review" element={<Review />} />
       <Route path="admin" element={<Admin />} />
+      <Route path="profile" element={<Profile />} />
       <Route path="settings" element={<Settings />} />
     </Route>
     <Route path="*" element={<Navigate to="/" replace />} />


### PR DESCRIPTION
## Summary
- wire the header dropdown to navigate to the profile and settings views while keeping the theme switch responsive
- add a dedicated profile page that surfaces basic user information within the dashboard
- register the new profile route in the dashboard router

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_690d26ebf4ac832e825488526d69f6d3