### PR TITLE
Add user profile update flow

### DIFF
--- a/backend/app/api/v1/routes_users.py
+++ b/backend/app/api/v1/routes_users.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from app.domain import repositories, schemas
+from app.infra import auth
+from app.infra.db import get_db
+
+router = APIRouter(prefix="/v1/users", tags=["users"])
+
+
+@router.patch("/me", response_model=schemas.UserRead)
+def update_me(
+    payload: schemas.UserUpdate,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+) -> schemas.UserRead:
+    user_repo = repositories.UserRepository(db)
+    update_data = payload.model_dump(exclude_unset=True)
+
+    sanitized: dict[str, object] = {}
+    for field, value in update_data.items():
+        if isinstance(value, str):
+            value = value.strip()
+            if not value:
+                value = None
+        sanitized[field] = value
+
+    updated_user = user_repo.update(current_user, **sanitized)
+    return schemas.UserRead.from_orm(updated_user)

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -20,6 +20,9 @@ class User(Base):
 
     id: int = Column(Integer, primary_key=True, index=True)
     username: str = Column(String(255), unique=True, nullable=False, index=True)
+    first_name: Optional[str] = Column(String(255), nullable=True)
+    last_name: Optional[str] = Column(String(255), nullable=True)
+    phone_number: Optional[str] = Column(String(32), nullable=True)
     hashed_password: str = Column(String(255), nullable=False)
     role: str = Column(String(50), nullable=False, default=UserRole.ASSISTANT.value)
     created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/app/domain/repositories.py
+++ b/backend/app/domain/repositories.py
@@ -22,6 +22,13 @@ class UserRepository:
         self.db.refresh(user)
         return user
 
+    def update(self, user: models.User, **data) -> models.User:
+        for field, value in data.items():
+            setattr(user, field, value)
+        self.db.commit()
+        self.db.refresh(user)
+        return user
+
 
 class JobRepository:
     def __init__(self, db: Session):

--- a/backend/app/domain/schemas.py
+++ b/backend/app/domain/schemas.py
@@ -24,10 +24,19 @@ class TokenPayload(BaseModel):
 class UserBase(BaseModel):
     username: str
     role: str = Field(default="assistant")
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    phone_number: Optional[str] = None
 
 
 class UserCreate(UserBase):
     password: str = Field(min_length=8)
+
+
+class UserUpdate(BaseModel):
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    phone_number: Optional[str] = None
 
 
 class UserRead(UserBase):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -10,6 +10,7 @@ from app.api.v1 import (
     routes_jobs,
     routes_reports,
     routes_transcribe,
+    routes_users,
 )
 from app.infra.logging import logger
 from app.infra.telemetry import record_metrics
@@ -34,6 +35,7 @@ app.include_router(routes_auth.router)
 app.include_router(routes_jobs.router)
 app.include_router(routes_reports.router)
 app.include_router(routes_transcribe.router)
+app.include_router(routes_users.router)
 
 
 @app.on_event("startup")

--- a/backend/migrations/versions/0002_add_user_profile_fields.py
+++ b/backend/migrations/versions/0002_add_user_profile_fields.py
@@ -1,0 +1,22 @@
+"""add user profile fields"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0002"
+down_revision = "0001"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("first_name", sa.String(length=255), nullable=True))
+    op.add_column("users", sa.Column("last_name", sa.String(length=255), nullable=True))
+    op.add_column("users", sa.Column("phone_number", sa.String(length=32), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "phone_number")
+    op.drop_column("users", "last_name")
+    op.drop_column("users", "first_name")

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -90,6 +90,17 @@ export const getCurrentUser = async (token) => {
   return handleResponse(response);
 };
 
+export const updateCurrentUser = async (token, payload) => {
+  const response = await fetch(`${API_BASE_URL}/v1/users/me`, {
+    method: "PATCH",
+    headers: buildHeaders(token, { "Content-Type": "application/json" }),
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  return handleResponse(response);
+};
+
 export const listJobs = async (token) => {
   const response = await fetch(`${API_BASE_URL}/v1/jobs`, {
     method: "GET",

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -11,14 +11,24 @@ import * as api from "../api/client";
 
 const UserContext = createContext();
 
-const normalizeUser = (user) => ({
-  id: user.id,
-  username: user.username,
-  name: user.username,
-  role: user.role,
-  createdAt: user.created_at,
-  updatedAt: user.updated_at,
-});
+const normalizeUser = (user) => {
+  const firstName = user.first_name ?? null;
+  const lastName = user.last_name ?? null;
+  const phoneNumber = user.phone_number ?? null;
+  const displayName = [firstName, lastName].filter(Boolean).join(" ") || user.username;
+
+  return {
+    id: user.id,
+    username: user.username,
+    name: displayName,
+    role: user.role,
+    createdAt: user.created_at,
+    updatedAt: user.updated_at,
+    firstName,
+    lastName,
+    phoneNumber,
+  };
+};
 
 export const UserProvider = ({ children }) => {
   const [user, setUser] = useState(null);


### PR DESCRIPTION
## Summary
- add optional profile fields to the user model, schemas, and migrations
- expose a /v1/users/me endpoint for updating profile details and wire it into the app
- update the settings screen and phone input component to edit and persist first name, last name, and phone number

## Testing
- pytest
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_690d2952a890832e931768a96050de83