### PR TITLE
Switch two-factor authentication to TOTP

### DIFF
--- a/backend/app/api/v1/routes_users.py
+++ b/backend/app/api/v1/routes_users.py
@@ -1,9 +1,16 @@
-from fastapi import APIRouter, Depends
+from datetime import datetime
+import secrets
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.orm import Session
 
 from app.domain import repositories, schemas
-from app.infra import auth
+from app.infra import auth, two_factor
 from app.infra.db import get_db
+from app.settings import get_settings
+
+settings = get_settings()
 
 router = APIRouter(prefix="/v1/users", tags=["users"])
 
@@ -17,7 +24,7 @@ def update_me(
     user_repo = repositories.UserRepository(db)
     update_data = payload.model_dump(exclude_unset=True)
 
-    sanitized: dict[str, object] = {}
+    sanitized: dict[str, Any] = {}
     for field, value in update_data.items():
         if isinstance(value, str):
             value = value.strip()
@@ -26,4 +33,164 @@ def update_me(
         sanitized[field] = value
 
     updated_user = user_repo.update(current_user, **sanitized)
-    return schemas.UserRead.from_orm(updated_user)
+    user_read = schemas.UserRead.from_orm(updated_user)
+    if updated_user.two_factor_enabled:
+        user_read = user_read.model_copy(update={"two_factor_method": "totp"})
+    return user_read
+
+
+@router.post("/me/change-password", status_code=status.HTTP_204_NO_CONTENT)
+def change_password(
+    payload: schemas.ChangePasswordRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+) -> Response:
+    if not auth.verify_password(payload.current_password, current_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Current password is incorrect.",
+        )
+    if payload.current_password == payload.new_password:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="New password must be different from the current password.",
+        )
+
+    user_repo = repositories.UserRepository(db)
+    hashed_password = auth.hash_password(payload.new_password)
+    user_repo.update(current_user, hashed_password=hashed_password)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+def _two_factor_status(user) -> schemas.TwoFactorStatus:
+    enabled = bool(user.two_factor_enabled and user.two_factor_shared_secret)
+    return schemas.TwoFactorStatus(
+        enabled=enabled,
+        confirmed=bool(user.two_factor_confirmed_at),
+        method="totp" if enabled else None,
+    )
+
+
+@router.post(
+    "/me/security/start-two-factor",
+    response_model=schemas.TwoFactorEnrollmentStart,
+)
+def start_two_factor_enrollment(
+    db: Session = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+) -> schemas.TwoFactorEnrollmentStart:
+    if current_user.two_factor_enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Two-factor authentication is already enabled.",
+        )
+
+    secret = two_factor.generate_totp_secret()
+    challenge_id = secrets.token_urlsafe(24)
+    expires_at = two_factor.enrollment_deadline()
+    expires_in = max(1, int((expires_at - datetime.utcnow()).total_seconds()))
+
+    user_repo = repositories.UserRepository(db)
+    updated = user_repo.update(
+        current_user,
+        two_factor_shared_secret=secret,
+        two_factor_challenge_token=challenge_id,
+        two_factor_challenge_expires_at=expires_at,
+        two_factor_enabled=False,
+        two_factor_confirmed_at=None,
+    )
+
+    provisioning_uri = two_factor.provisioning_uri(
+        secret, updated.username, settings.APP_NAME
+    )
+    debug_code = (
+        two_factor.active_debug_code(secret)
+        if settings.ENV.lower() != "production"
+        else None
+    )
+
+    return schemas.TwoFactorEnrollmentStart(
+        challenge_id=challenge_id,
+        secret=secret,
+        provisioning_uri=provisioning_uri,
+        expires_in_seconds=expires_in,
+        debug_code=debug_code,
+    )
+
+
+@router.post(
+    "/me/security/enable-two-factor",
+    response_model=schemas.TwoFactorStatus,
+)
+def enable_two_factor(
+    payload: schemas.TwoFactorEnableRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+) -> schemas.TwoFactorStatus:
+    if (
+        not current_user.two_factor_challenge_token
+        or not current_user.two_factor_shared_secret
+        or not current_user.two_factor_challenge_expires_at
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="No active two-factor enrollment. Start again to continue.",
+        )
+
+    if payload.challenge_id != current_user.two_factor_challenge_token:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid verification challenge.",
+        )
+
+    if current_user.two_factor_challenge_expires_at < datetime.utcnow():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Two-factor enrollment has expired. Start again.",
+        )
+
+    if not two_factor.verify_totp(payload.code, current_user.two_factor_shared_secret):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Invalid verification code.",
+        )
+
+    user_repo = repositories.UserRepository(db)
+    updated = user_repo.update(
+        current_user,
+        two_factor_enabled=True,
+        two_factor_confirmed_at=datetime.utcnow(),
+        two_factor_challenge_token=None,
+        two_factor_challenge_expires_at=None,
+    )
+    return _two_factor_status(updated)
+
+
+@router.post(
+    "/me/security/disable-two-factor",
+    response_model=schemas.TwoFactorStatus,
+)
+def disable_two_factor(
+    payload: schemas.TwoFactorDisableRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+) -> schemas.TwoFactorStatus:
+    if not current_user.two_factor_enabled:
+        return _two_factor_status(current_user)
+
+    if not auth.verify_password(payload.current_password, current_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Current password is incorrect.",
+        )
+
+    user_repo = repositories.UserRepository(db)
+    updated = user_repo.update(
+        current_user,
+        two_factor_enabled=False,
+        two_factor_confirmed_at=None,
+        two_factor_shared_secret=None,
+        two_factor_challenge_token=None,
+        two_factor_challenge_expires_at=None,
+    )
+    return _two_factor_status(updated)

--- a/backend/app/domain/repositories.py
+++ b/backend/app/domain/repositories.py
@@ -15,6 +15,13 @@ class UserRepository:
     def get(self, user_id: int) -> Optional[models.User]:
         return self.db.query(models.User).filter(models.User.id == user_id).first()
 
+    def get_by_two_factor_challenge(self, challenge_id: str) -> Optional[models.User]:
+        return (
+            self.db.query(models.User)
+            .filter(models.User.two_factor_challenge_token == challenge_id)
+            .first()
+        )
+
     def create(self, username: str, hashed_password: str, role: str) -> models.User:
         user = models.User(username=username, hashed_password=hashed_password, role=role)
         self.db.add(user)

--- a/backend/app/infra/two_factor.py
+++ b/backend/app/infra/two_factor.py
@@ -1,0 +1,128 @@
+"""Helpers for time-based one-time password (TOTP) two-factor workflows."""
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+import re
+import secrets
+import string
+import time
+from datetime import datetime, timedelta
+from typing import Optional
+from urllib.parse import quote
+
+_CODE_PATTERN = re.compile(r"\D+")
+_DEFAULT_CHALLENGE_MINUTES = 10
+_DEFAULT_LOGIN_MINUTES = 5
+_SECRET_ALPHABET = string.ascii_uppercase + "234567"
+_TOTP_DIGITS = 6
+_TIME_STEP = 30
+
+
+def _normalize_code(code: str | None) -> str:
+    if not code:
+        return ""
+    return _CODE_PATTERN.sub("", code)
+
+
+def _totp_counter(timestamp: Optional[float] = None) -> int:
+    ts = timestamp if timestamp is not None else time.time()
+    return int(ts // _TIME_STEP)
+
+
+def _decode_secret(secret: str) -> bytes:
+    normalized = secret.strip().replace(" ", "").upper()
+    padding = "=" * ((8 - len(normalized) % 8) % 8)
+    return base64.b32decode(normalized + padding)
+
+
+def _hotp(secret: bytes, counter: int) -> int:
+    msg = counter.to_bytes(8, byteorder="big")
+    digest = hmac.new(secret, msg, hashlib.sha1).digest()
+    offset = digest[-1] & 0x0F
+    truncated = digest[offset : offset + 4]
+    code_int = int.from_bytes(truncated, byteorder="big") & 0x7FFFFFFF
+    return code_int % (10**_TOTP_DIGITS)
+
+
+def _generate_secret(length: int = 32) -> str:
+    return "".join(secrets.choice(_SECRET_ALPHABET) for _ in range(length))
+
+
+def generate_totp_secret(length: int = 32) -> str:
+    """Generate a random base32 secret for a TOTP authenticator."""
+
+    return _generate_secret(length)
+
+
+def provisioning_uri(secret: str, username: str, issuer: str) -> str:
+    """Create an otpauth URI for authenticator applications."""
+
+    issuer_part = quote(issuer)
+    user_part = quote(username)
+    label = f"{issuer_part}:{user_part}"
+    return f"otpauth://totp/{label}?secret={secret}&issuer={issuer_part}"
+
+
+def _totp_code(secret: str, counter: int) -> str:
+    secret_bytes = _decode_secret(secret)
+    code_int = _hotp(secret_bytes, counter)
+    return f"{code_int:0{_TOTP_DIGITS}d}"
+
+
+def verify_totp(code: str, secret: str) -> bool:
+    """Validate a user supplied TOTP code against the shared secret."""
+
+    normalized = _normalize_code(code)
+    if not normalized or not secret:
+        return False
+
+    try:
+        secret_bytes = _decode_secret(secret)
+    except (binascii.Error, ValueError):
+        return False
+
+    current_counter = _totp_counter()
+    for offset in (-1, 0, 1):
+        counter = current_counter + offset
+        if counter < 0:
+            continue
+        expected = _hotp(secret_bytes, counter)
+        if normalized == f"{expected:0{_TOTP_DIGITS}d}":
+            return True
+    return False
+
+
+def active_debug_code(secret: Optional[str]) -> Optional[str]:
+    """Return the current TOTP code for debugging in non-production envs."""
+
+    if not secret:
+        return None
+    try:
+        return _totp_code(secret, _totp_counter())
+    except (binascii.Error, ValueError):
+        return None
+
+
+def enrollment_deadline(minutes: int = _DEFAULT_CHALLENGE_MINUTES) -> datetime:
+    """Return when an enrollment challenge should expire."""
+
+    return datetime.utcnow() + timedelta(minutes=minutes)
+
+
+def login_challenge_deadline(minutes: int = _DEFAULT_LOGIN_MINUTES) -> datetime:
+    """Return when a login verification challenge should expire."""
+
+    return datetime.utcnow() + timedelta(minutes=minutes)
+
+
+__all__ = [
+    "active_debug_code",
+    "enrollment_deadline",
+    "generate_totp_secret",
+    "login_challenge_deadline",
+    "provisioning_uri",
+    "verify_totp",
+]

--- a/backend/migrations/versions/0003_add_two_factor_fields.py
+++ b/backend/migrations/versions/0003_add_two_factor_fields.py
@@ -1,0 +1,56 @@
+"""Add two-factor authentication fields to users.
+
+Revision ID: 0003_add_two_factor_fields
+Revises: 0002_add_user_profile_fields
+Create Date: 2024-05-20 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0003_add_two_factor_fields"
+down_revision = "0002_add_user_profile_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "two_factor_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.add_column(
+        "users",
+        sa.Column("two_factor_challenge_token", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("two_factor_challenge_expires_at", sa.DateTime(), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("two_factor_shared_secret", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column("two_factor_confirmed_at", sa.DateTime(), nullable=True),
+    )
+
+    op.execute("UPDATE users SET two_factor_enabled = FALSE WHERE two_factor_enabled IS NULL")
+    op.alter_column("users", "two_factor_enabled", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("users", "two_factor_challenge_token")
+    op.drop_column("users", "two_factor_confirmed_at")
+    op.drop_column("users", "two_factor_shared_secret")
+    op.drop_column("users", "two_factor_challenge_expires_at")
+    op.drop_column("users", "two_factor_enabled")

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -101,6 +101,69 @@ export const updateCurrentUser = async (token, payload) => {
   return handleResponse(response);
 };
 
+export const changePassword = async (token, payload) => {
+  const response = await fetch(`${API_BASE_URL}/v1/users/me/change-password`, {
+    method: "POST",
+    headers: buildHeaders(token, { "Content-Type": "application/json" }),
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  return handleResponse(response);
+};
+
+export const startTwoFactorEnrollment = async (token) => {
+  const response = await fetch(
+    `${API_BASE_URL}/v1/users/me/security/start-two-factor`,
+    {
+      method: "POST",
+      headers: buildHeaders(token, { "Content-Type": "application/json" }),
+      credentials: "include",
+    }
+  );
+
+  return handleResponse(response);
+};
+
+export const enableTwoFactor = async (token, payload) => {
+  const response = await fetch(
+    `${API_BASE_URL}/v1/users/me/security/enable-two-factor`,
+    {
+      method: "POST",
+      headers: buildHeaders(token, { "Content-Type": "application/json" }),
+      credentials: "include",
+      body: JSON.stringify(payload),
+    }
+  );
+
+  return handleResponse(response);
+};
+
+export const disableTwoFactor = async (token, payload) => {
+  const response = await fetch(
+    `${API_BASE_URL}/v1/users/me/security/disable-two-factor`,
+    {
+      method: "POST",
+      headers: buildHeaders(token, { "Content-Type": "application/json" }),
+      credentials: "include",
+      body: JSON.stringify(payload),
+    }
+  );
+
+  return handleResponse(response);
+};
+
+export const verifyTwoFactorLogin = async ({ challengeId, code }) => {
+  const response = await fetch(`${API_BASE_URL}/v1/auth/login/verify`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ challenge_id: challengeId, code }),
+  });
+
+  return handleResponse(response);
+};
+
 export const listJobs = async (token) => {
   const response = await fetch(`${API_BASE_URL}/v1/jobs`, {
     method: "GET",

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -16,6 +16,9 @@ const normalizeUser = (user) => {
   const lastName = user.last_name ?? null;
   const phoneNumber = user.phone_number ?? null;
   const displayName = [firstName, lastName].filter(Boolean).join(" ") || user.username;
+  const twoFactorEnabled = Boolean(user.two_factor_enabled);
+  const twoFactorConfirmed = Boolean(user.two_factor_confirmed);
+  const twoFactorMethod = user.two_factor_method ?? (twoFactorEnabled ? "totp" : null);
 
   return {
     id: user.id,
@@ -27,6 +30,9 @@ const normalizeUser = (user) => {
     firstName,
     lastName,
     phoneNumber,
+    twoFactorEnabled,
+    twoFactorConfirmed,
+    twoFactorMethod,
   };
 };
 
@@ -147,12 +153,42 @@ export const UserProvider = ({ children }) => {
       setLoading(true);
       try {
         const authResponse = await api.login(username, password);
+        if (authResponse?.requires_two_factor) {
+          return {
+            requiresTwoFactor: true,
+            challengeId: authResponse.challenge_id,
+            method: authResponse.method,
+            expiresInSeconds: authResponse.expires_in_seconds,
+            debugCode: authResponse.debug_code ?? null,
+          };
+        }
         if (!authResponse?.access_token) {
           throw new Error("No access token returned by server");
         }
         setAccessToken(authResponse.access_token);
         await fetchCurrentUser(authResponse.access_token);
-        return authResponse;
+        return { requiresTwoFactor: false, access_token: authResponse.access_token };
+      } catch (error) {
+        clearSession();
+        throw error;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [fetchCurrentUser, clearSession]
+  );
+
+  const completeTwoFactorLogin = useCallback(
+    async (challengeId, code) => {
+      setLoading(true);
+      try {
+        const response = await api.verifyTwoFactorLogin({ challengeId, code });
+        if (!response?.access_token) {
+          throw new Error("No access token returned by server");
+        }
+        setAccessToken(response.access_token);
+        await fetchCurrentUser(response.access_token);
+        return response;
       } catch (error) {
         clearSession();
         throw error;
@@ -197,13 +233,24 @@ export const UserProvider = ({ children }) => {
       accessToken,
       loading,
       login,
+      completeTwoFactorLogin,
       register,
       logout,
       refreshUser,
       callWithAuth,
       isAuthenticated: Boolean(user && accessToken),
     }),
-    [user, accessToken, loading, login, register, logout, refreshUser, callWithAuth]
+    [
+      user,
+      accessToken,
+      loading,
+      login,
+      completeTwoFactorLogin,
+      register,
+      logout,
+      refreshUser,
+      callWithAuth,
+    ]
   );
 
   return <UserContext.Provider value={value}>{children}</UserContext.Provider>;

--- a/frontend/src/pages/login/Login.jsx
+++ b/frontend/src/pages/login/Login.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Card, Input, Button, message } from "antd";
+import { Card, Input, Button, message, Alert } from "antd";
 import { Link, Navigate, useNavigate } from "react-router-dom";
 import { Stethoscope } from "lucide-react";
 import { useUser } from "../../context/UserContext.jsx";
@@ -8,18 +8,35 @@ const LoginForm = () => {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [twoFactorChallenge, setTwoFactorChallenge] = useState(null);
+  const [twoFactorCode, setTwoFactorCode] = useState("");
+  const [pendingCredentials, setPendingCredentials] = useState(null);
   const navigate = useNavigate();
-  const { login, isAuthenticated } = useUser();
+  const { login, isAuthenticated, completeTwoFactorLogin } = useUser();
 
   if (isAuthenticated) {
     return <Navigate to="/dashboard" replace />;
   }
 
+  const resetTwoFactorState = () => {
+    setTwoFactorChallenge(null);
+    setTwoFactorCode("");
+    setPendingCredentials(null);
+  };
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     setSubmitting(true);
     try {
-      await login(username, password);
+      const result = await login(username, password);
+      if (result?.requiresTwoFactor) {
+        setPendingCredentials({ username, password });
+        setTwoFactorChallenge(result);
+        setTwoFactorCode("");
+        message.info("Open your authenticator app to retrieve your security code.");
+        return;
+      }
+      resetTwoFactorState();
       message.success("Logged in successfully");
       navigate("/dashboard");
     } catch (error) {
@@ -27,6 +44,58 @@ const LoginForm = () => {
     } finally {
       setSubmitting(false);
     }
+  };
+
+  const handleVerifyTwoFactor = async (e) => {
+    e.preventDefault();
+    if (!twoFactorChallenge) {
+      return;
+    }
+    const trimmed = twoFactorCode.trim();
+    if (trimmed.length < 4) {
+      message.error("Enter the 6-digit code from your authenticator app.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await completeTwoFactorLogin(twoFactorChallenge.challengeId, trimmed);
+      resetTwoFactorState();
+      message.success("Logged in successfully");
+      navigate("/dashboard");
+    } catch (error) {
+      message.error(error?.message ?? "Invalid verification code");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRefreshChallenge = async () => {
+    if (!pendingCredentials) {
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const result = await login(pendingCredentials.username, pendingCredentials.password);
+      if (result?.requiresTwoFactor) {
+        setTwoFactorChallenge(result);
+        setTwoFactorCode("");
+        message.success("Login challenge refreshed. Use a new authenticator code.");
+        return;
+      }
+      resetTwoFactorState();
+      message.success("Logged in successfully");
+      navigate("/dashboard");
+    } catch (error) {
+      message.error(error?.message ?? "Unable to refresh login challenge");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleCodeChange = (e) => {
+    const digitsOnly = e.target.value.replace(/\D/g, "").slice(0, 6);
+    setTwoFactorCode(digitsOnly);
   };
 
   return (
@@ -43,51 +112,100 @@ const LoginForm = () => {
         }
         className="w-full max-w-md"
       >
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div className="space-y-1">
-            <label htmlFor="username" className="block text-sm font-medium text-gray-700">
-              Username
-            </label>
-            <Input
-              id="username"
-              placeholder="doctor@hospital.com"
-              value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              required
-            />
-          </div>
+        {!twoFactorChallenge ? (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1">
+              <label htmlFor="username" className="block text-sm font-medium text-gray-700">
+                Username
+              </label>
+              <Input
+                id="username"
+                placeholder="doctor@hospital.com"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                required
+                disabled={submitting}
+              />
+            </div>
 
-          <div className="space-y-1">
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700">
-              Password
-            </label>
-            <Input.Password
-              id="password"
-              placeholder="••••••••"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-            />
-          </div>
+            <div className="space-y-1">
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                Password
+              </label>
+              <Input.Password
+                id="password"
+                placeholder="••••••••"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                disabled={submitting}
+              />
+            </div>
 
-          <Button type="primary" htmlType="submit" className="w-full" loading={submitting}>
-            Sign In
-          </Button>
-          <div className="flex flex-col items-center gap-2 text-sm text-gray-600">
-            <p>
-              Forgot my password?{" "}
-              <Link to="/forgot-password" className="font-medium text-blue-600 hover:text-blue-500">
-                Reset password
-              </Link>
-            </p>
-            <p>
-              Don&apos;t have an account?{" "}
-              <Link to="/signup" className="font-medium text-blue-600 hover:text-blue-500">
-                Sign up
-              </Link>
-            </p>
-          </div>
-        </form>
+            <Button type="primary" htmlType="submit" className="w-full" loading={submitting}>
+              Sign In
+            </Button>
+            <div className="flex flex-col items-center gap-2 text-sm text-gray-600">
+              <p>
+                Forgot my password?{" "}
+                <Link to="/forgot-password" className="font-medium text-blue-600 hover:text-blue-500">
+                  Reset password
+                </Link>
+              </p>
+              <p>
+                Don&apos;t have an account?{" "}
+                <Link to="/signup" className="font-medium text-blue-600 hover:text-blue-500">
+                  Sign up
+                </Link>
+              </p>
+            </div>
+          </form>
+        ) : (
+          <form onSubmit={handleVerifyTwoFactor} className="space-y-4">
+            <Alert
+              type="info"
+              showIcon
+              message="Enter the 6-digit code generated by your authenticator app."
+            />
+            {twoFactorChallenge.debugCode ? (
+              <Alert
+                type="warning"
+                showIcon
+                message={`Development code: ${twoFactorChallenge.debugCode}`}
+              />
+            ) : null}
+
+            <div className="space-y-1">
+              <label htmlFor="twoFactorCode" className="block text-sm font-medium text-gray-700">
+                Verification Code
+              </label>
+              <Input
+                id="twoFactorCode"
+                placeholder="123456"
+                value={twoFactorCode}
+                onChange={handleCodeChange}
+                inputMode="numeric"
+                maxLength={6}
+                disabled={submitting}
+              />
+            </div>
+
+            <Button type="primary" htmlType="submit" className="w-full" loading={submitting}>
+              Verify &amp; Sign In
+            </Button>
+            <Button
+              type="default"
+              className="w-full"
+              onClick={handleRefreshChallenge}
+              disabled={submitting || !pendingCredentials}
+            >
+              Refresh challenge
+            </Button>
+            <Button type="link" onClick={resetTwoFactorState} disabled={submitting}>
+              Use a different account
+            </Button>
+          </form>
+        )}
       </Card>
     </div>
   );

--- a/frontend/src/pages/settings/Settings.jsx
+++ b/frontend/src/pages/settings/Settings.jsx
@@ -1,13 +1,18 @@
 // src/pages/settings/Settings.jsx
 import React, { useEffect, useMemo, useState, useCallback } from "react";
 import {
+  Alert,
   Button,
   Card,
   ConfigProvider,
+  Divider,
   Input,
+  Modal,
   Select,
   Switch,
   Tabs,
+  Tag,
+  Typography,
   message,
 } from "antd";
 import {
@@ -21,7 +26,13 @@ import {
 import PhoneNumberInput from "../../components/phoneNumberInput/PhoneNumberInput";
 import { useUser } from "../../context/UserContext.jsx";
 import { useTheme } from "../../context/ThemeContext";
-import { updateCurrentUser } from "../../api/client";
+import {
+  updateCurrentUser,
+  changePassword,
+  startTwoFactorEnrollment,
+  enableTwoFactor,
+  disableTwoFactor,
+} from "../../api/client";
 
 const { Option } = Select;
 
@@ -80,21 +91,292 @@ const ProfileCard = React.memo(function ProfileCard({
 });
 
 const SecurityCard = React.memo(function SecurityCard() {
-  return (
-    <Card title="Password & Security" extra={<Lock className="w-5 h-5" />}>
-      <Input.Password placeholder="Current Password" className="mt-2" />
-      <Input.Password placeholder="New Password" className="mt-4" />
-      <Input.Password placeholder="Confirm New Password" className="mt-4" />
+  const { user, callWithAuth, refreshUser } = useUser();
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [updatingPassword, setUpdatingPassword] = useState(false);
 
-      <div className="flex justify-between items-center mt-4">
-        <span>Two-Factor Authentication</span>
-        <Switch />
-      </div>
-      <div className="flex justify-between items-center mt-4">
-        <span>Login Notifications</span>
-        <Switch defaultChecked />
-      </div>
-    </Card>
+  const [twoFactorEnrollment, setTwoFactorEnrollment] = useState(null);
+  const [twoFactorCode, setTwoFactorCode] = useState("");
+  const [startingEnrollment, setStartingEnrollment] = useState(false);
+  const [verifyingTwoFactor, setVerifyingTwoFactor] = useState(false);
+  const [disableModalVisible, setDisableModalVisible] = useState(false);
+  const [disablePassword, setDisablePassword] = useState("");
+  const [disablingTwoFactor, setDisablingTwoFactor] = useState(false);
+
+  const twoFactorEnabled = Boolean(user?.twoFactorEnabled);
+  const twoFactorConfirmed = Boolean(user?.twoFactorConfirmed);
+
+  useEffect(() => {
+    setTwoFactorEnrollment(null);
+    setTwoFactorCode("");
+  }, [twoFactorEnabled]);
+
+  const handlePasswordUpdate = async () => {
+    if (!currentPassword || !newPassword || !confirmPassword) {
+      message.error("Fill in all password fields before updating.");
+      return;
+    }
+    if (newPassword !== confirmPassword) {
+      message.error("New passwords do not match.");
+      return;
+    }
+    if (newPassword.length < 8) {
+      message.error("New password must be at least 8 characters long.");
+      return;
+    }
+
+    setUpdatingPassword(true);
+    try {
+      await callWithAuth((token) =>
+        changePassword(token, {
+          current_password: currentPassword,
+          new_password: newPassword,
+        })
+      );
+      setCurrentPassword("");
+      setNewPassword("");
+      setConfirmPassword("");
+      message.success("Password updated successfully.");
+    } catch (error) {
+      message.error(error?.message ?? "Unable to update password");
+    } finally {
+      setUpdatingPassword(false);
+    }
+  };
+
+  const handleStartTwoFactorEnrollment = async () => {
+    setStartingEnrollment(true);
+    try {
+      const response = await callWithAuth(startTwoFactorEnrollment);
+      setTwoFactorEnrollment(response);
+      setTwoFactorCode("");
+      message.success(
+        "Scan the QR code or enter the secret into your authenticator app, then enter the code it generates."
+      );
+    } catch (error) {
+      message.error(error?.message ?? "Unable to start two-factor enrollment");
+    } finally {
+      setStartingEnrollment(false);
+    }
+  };
+
+  const handleTwoFactorCodeChange = (e) => {
+    const digitsOnly = e.target.value.replace(/\D/g, "").slice(0, 6);
+    setTwoFactorCode(digitsOnly);
+  };
+
+  const handleVerifyTwoFactor = async () => {
+    if (!twoFactorEnrollment) {
+      return;
+    }
+    const trimmed = twoFactorCode.trim();
+    if (trimmed.length < 4) {
+      message.error("Enter the 6-digit code from your authenticator app.");
+      return;
+    }
+
+    setVerifyingTwoFactor(true);
+    try {
+      await callWithAuth((token) =>
+        enableTwoFactor(token, {
+          challenge_id: twoFactorEnrollment.challenge_id,
+          code: trimmed,
+        })
+      );
+      await refreshUser();
+      setTwoFactorEnrollment(null);
+      setTwoFactorCode("");
+      message.success("Two-factor authentication is now enabled.");
+    } catch (error) {
+      message.error(error?.message ?? "Unable to enable two-factor authentication");
+    } finally {
+      setVerifyingTwoFactor(false);
+    }
+  };
+
+  const handleDisableTwoFactor = async () => {
+    if (!disablePassword) {
+      message.error("Enter your current password to disable two-factor authentication.");
+      return;
+    }
+    setDisablingTwoFactor(true);
+    try {
+      await callWithAuth((token) =>
+        disableTwoFactor(token, { current_password: disablePassword })
+      );
+      await refreshUser();
+      setDisablePassword("");
+      setDisableModalVisible(false);
+      message.success("Two-factor authentication disabled.");
+    } catch (error) {
+      message.error(error?.message ?? "Unable to disable two-factor authentication");
+    } finally {
+      setDisablingTwoFactor(false);
+    }
+  };
+
+  return (
+    <>
+      <Card title="Password & Security" extra={<Lock className="w-5 h-5" />}>
+        <div className="space-y-4">
+          <div>
+            <h4 className="font-medium mb-2">Change Password</h4>
+            <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+              <Input.Password
+                placeholder="Current password"
+                value={currentPassword}
+                onChange={(e) => setCurrentPassword(e.target.value)}
+              />
+              <Input.Password
+                placeholder="New password"
+                value={newPassword}
+                onChange={(e) => setNewPassword(e.target.value)}
+              />
+              <Input.Password
+                placeholder="Confirm new password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+              />
+            </div>
+            <Button
+              className="mt-3"
+              type="primary"
+              onClick={handlePasswordUpdate}
+              loading={updatingPassword}
+            >
+              Update Password
+            </Button>
+          </div>
+
+          <Divider />
+
+          <div className="space-y-3">
+            <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+              <div>
+                <h4 className="font-medium">Two-Factor Authentication</h4>
+                <p className="text-sm text-muted-foreground">
+                  Secure your account by requiring a verification code at sign-in.
+                </p>
+              </div>
+              <Tag color={twoFactorEnabled ? "success" : "default"}>
+                {twoFactorEnabled ? "Enabled" : "Disabled"}
+              </Tag>
+            </div>
+
+            {!twoFactorEnabled ? (
+              <div className="space-y-3">
+                {twoFactorEnrollment ? (
+                  <>
+                    <Alert
+                      type="info"
+                      showIcon
+                      message="Scan the QR code or enter the secret into your authenticator app, then verify the 6-digit code."
+                    />
+                    {twoFactorEnrollment?.debug_code ? (
+                      <Alert
+                        type="warning"
+                        showIcon
+                        message={`Development code: ${twoFactorEnrollment.debug_code}`}
+                      />
+                    ) : null}
+                    <div className="space-y-2 bg-gray-50 border border-dashed border-gray-300 rounded-md p-3">
+                      <Typography.Paragraph className="mb-0" strong>
+                        Authenticator Secret:
+                      </Typography.Paragraph>
+                      <Typography.Paragraph className="mb-0" copyable>
+                        <Typography.Text code>{twoFactorEnrollment.secret}</Typography.Text>
+                      </Typography.Paragraph>
+                      <Typography.Paragraph className="mb-0">
+                        <Typography.Link
+                          href={twoFactorEnrollment.provisioning_uri}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          Open setup link
+                        </Typography.Link>
+                      </Typography.Paragraph>
+                    </div>
+                    <div className="flex flex-col sm:flex-row gap-3">
+                      <Input
+                        placeholder="123456"
+                        value={twoFactorCode}
+                        onChange={handleTwoFactorCodeChange}
+                        inputMode="numeric"
+                        maxLength={6}
+                      />
+                      <Button
+                        type="primary"
+                        onClick={handleVerifyTwoFactor}
+                        loading={verifyingTwoFactor}
+                      >
+                        Verify Code
+                      </Button>
+                    </div>
+                  </>
+                ) : (
+                  <Button
+                    type="primary"
+                    onClick={handleStartTwoFactorEnrollment}
+                    loading={startingEnrollment}
+                  >
+                    Set up authenticator app
+                  </Button>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <Alert
+                  type={twoFactorConfirmed ? "success" : "info"}
+                  showIcon
+                  message={
+                    twoFactorConfirmed
+                      ? "Two-factor authentication is active for your account."
+                      : "Finish setup by verifying a code from your authenticator app."
+                  }
+                  description="Authenticator codes will be required whenever you sign in."
+                />
+                <Button danger onClick={() => setDisableModalVisible(true)}>
+                  Disable two-factor authentication
+                </Button>
+              </div>
+            )}
+          </div>
+
+          <Divider />
+
+          <div className="flex justify-between items-center">
+            <span>Login Notifications</span>
+            <Switch defaultChecked />
+          </div>
+        </div>
+      </Card>
+
+      <Modal
+        title="Disable two-factor authentication"
+        open={disableModalVisible}
+        onCancel={() => {
+          if (!disablingTwoFactor) {
+            setDisableModalVisible(false);
+            setDisablePassword("");
+          }
+        }}
+        onOk={handleDisableTwoFactor}
+        okText="Disable"
+        okButtonProps={{ danger: true }}
+        confirmLoading={disablingTwoFactor}
+      >
+        <p className="text-sm text-muted-foreground mb-2">
+          Enter your current password to confirm that you want to disable two-factor authentication.
+        </p>
+        <Input.Password
+          placeholder="Current password"
+          value={disablePassword}
+          onChange={(e) => setDisablePassword(e.target.value)}
+        />
+      </Modal>
+    </>
   );
 });
 


### PR DESCRIPTION
## Summary
- replace the previous SMS verification flow with time-based one-time password helpers, storage fields, and API routes
- adapt user schemas, migrations, and login handling to work with authenticator-driven challenges instead of phone numbers
- refresh the frontend settings and login experiences to guide users through TOTP enrollment and verification

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_690d338552b8832e978d0a5c05b99ec6