### PR TITLE
Add security management and TOTP two-factor auth

### DIFF
--- a/backend/app/api/v1/routes_users.py
+++ b/backend/app/api/v1/routes_users.py
@@ -1,9 +1,10 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, Response, status
 from sqlalchemy.orm import Session
 
 from app.domain import repositories, schemas
 from app.infra import auth
 from app.infra.db import get_db
+from app.services import totp as totp_service
 
 router = APIRouter(prefix="/v1/users", tags=["users"])
 
@@ -27,3 +28,88 @@ def update_me(
 
     updated_user = user_repo.update(current_user, **sanitized)
     return schemas.UserRead.from_orm(updated_user)
+
+
+@router.post("/me/password", status_code=status.HTTP_204_NO_CONTENT)
+def change_password(
+    payload: schemas.ChangePasswordRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+) -> Response:
+    if not auth.verify_password(payload.current_password, current_user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Current password is incorrect")
+
+    if auth.verify_password(payload.new_password, current_user.hashed_password):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="New password must be different from the current password",
+        )
+
+    user_repo = repositories.UserRepository(db)
+    hashed = auth.hash_password(payload.new_password)
+    user_repo.update(current_user, hashed_password=hashed)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/me/totp/setup", response_model=schemas.TOTPSetupResponse)
+def initiate_totp_setup(
+    db: Session = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+) -> schemas.TOTPSetupResponse:
+    if current_user.totp_enabled:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Two-factor authentication is already enabled")
+
+    secret = totp_service.generate_secret()
+    user_repo = repositories.UserRepository(db)
+    user_repo.update(current_user, totp_secret_pending=secret, totp_secret=None, totp_enabled=False)
+
+    otpauth_url = totp_service.build_otpauth_url(secret, current_user.username)
+    return schemas.TOTPSetupResponse(secret=secret, otpauth_url=otpauth_url)
+
+
+@router.post("/me/totp/verify", response_model=schemas.TOTPStatus)
+def verify_totp_setup(
+    payload: schemas.TOTPVerifyRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+) -> schemas.TOTPStatus:
+    if current_user.totp_enabled:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Two-factor authentication is already enabled")
+
+    pending_secret = current_user.totp_secret_pending
+    if not pending_secret:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No pending two-factor authentication setup")
+
+    if not totp_service.verify_code(pending_secret, payload.code):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid authentication code")
+
+    user_repo = repositories.UserRepository(db)
+    user_repo.update(
+        current_user,
+        totp_secret=pending_secret,
+        totp_secret_pending=None,
+        totp_enabled=True,
+    )
+    return schemas.TOTPStatus(enabled=True)
+
+
+@router.post("/me/totp/disable", response_model=schemas.TOTPStatus)
+def disable_totp(
+    payload: schemas.TOTPDisableRequest,
+    db: Session = Depends(get_db),
+    current_user=Depends(auth.get_current_user),
+) -> schemas.TOTPStatus:
+    if not current_user.totp_enabled:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Two-factor authentication is not enabled")
+
+    if not auth.verify_password(payload.current_password, current_user.hashed_password):
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Current password is incorrect")
+
+    user_repo = repositories.UserRepository(db)
+    user_repo.update(
+        current_user,
+        totp_secret=None,
+        totp_secret_pending=None,
+        totp_enabled=False,
+    )
+    return schemas.TOTPStatus(enabled=False)

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import Enum as PyEnum
 from typing import Optional
 
-from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import declarative_base, relationship
 
 
@@ -25,6 +25,9 @@ class User(Base):
     phone_number: Optional[str] = Column(String(32), nullable=True)
     hashed_password: str = Column(String(255), nullable=False)
     role: str = Column(String(50), nullable=False, default=UserRole.ASSISTANT.value)
+    totp_secret: Optional[str] = Column(String(255), nullable=True)
+    totp_secret_pending: Optional[str] = Column(String(255), nullable=True)
+    totp_enabled: bool = Column(Boolean, nullable=False, default=False)
     created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
     updated_at: datetime = Column(
         DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False

--- a/backend/app/domain/schemas.py
+++ b/backend/app/domain/schemas.py
@@ -13,6 +13,7 @@ class Token(BaseModel):
 class LoginRequest(BaseModel):
     username: str
     password: str
+    totp_code: Optional[str] = None
 
 
 class TokenPayload(BaseModel):
@@ -43,8 +44,31 @@ class UserRead(UserBase):
     id: int
     created_at: datetime
     updated_at: datetime
+    totp_enabled: bool = False
 
     model_config = ConfigDict(from_attributes=True)
+
+
+class ChangePasswordRequest(BaseModel):
+    current_password: str = Field(min_length=1)
+    new_password: str = Field(min_length=8)
+
+
+class TOTPSetupResponse(BaseModel):
+    secret: str
+    otpauth_url: str
+
+
+class TOTPVerifyRequest(BaseModel):
+    code: str = Field(min_length=6, max_length=8)
+
+
+class TOTPDisableRequest(BaseModel):
+    current_password: str = Field(min_length=1)
+
+
+class TOTPStatus(BaseModel):
+    enabled: bool
 
 
 class JobBase(BaseModel):

--- a/backend/app/services/totp.py
+++ b/backend/app/services/totp.py
@@ -1,0 +1,85 @@
+"""Utilities for managing time-based one-time password (TOTP) secrets."""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import re
+import secrets
+import time
+from urllib.parse import quote
+
+from app.settings import get_settings
+
+_settings = get_settings()
+
+_CODE_PATTERN = re.compile(r"\s+")
+_PERIOD = 30
+_DIGITS = 6
+
+
+def _pad_base32(value: str) -> str:
+    missing_padding = (-len(value)) % 8
+    if missing_padding:
+        value += "=" * missing_padding
+    return value
+
+
+def generate_secret(length: int = 20) -> str:
+    """Return a new base32-encoded secret suitable for TOTP."""
+
+    random_bytes = secrets.token_bytes(length)
+    secret = base64.b32encode(random_bytes).decode("utf-8").rstrip("=")
+    return secret
+
+
+def build_otpauth_url(secret: str, username: str) -> str:
+    """Return an otpauth:// provisioning URI for the given user."""
+
+    issuer = quote(_settings.APP_NAME)
+    label = quote(f"{_settings.APP_NAME}:{username}", safe=":")
+    params = f"secret={secret}&issuer={issuer}&algorithm=SHA1&digits={_DIGITS}&period={_PERIOD}"
+    return f"otpauth://totp/{label}?{params}"
+
+
+def _generate_otp(secret: str, for_time: float) -> str:
+    padded_secret = _pad_base32(secret.upper())
+    key = base64.b32decode(padded_secret, casefold=True)
+    counter = int(for_time // _PERIOD)
+    counter_bytes = counter.to_bytes(8, "big")
+    hmac_digest = hmac.new(key, counter_bytes, hashlib.sha1).digest()
+    offset = hmac_digest[-1] & 0x0F
+    code = (
+        ((hmac_digest[offset] & 0x7F) << 24)
+        | ((hmac_digest[offset + 1] & 0xFF) << 16)
+        | ((hmac_digest[offset + 2] & 0xFF) << 8)
+        | (hmac_digest[offset + 3] & 0xFF)
+    )
+    otp = code % (10**_DIGITS)
+    return f"{otp:0{_DIGITS}d}"
+
+
+def _normalize_code(code: str) -> str:
+    return _CODE_PATTERN.sub("", code.strip())
+
+
+def verify_code(secret: str, code: str, *, valid_window: int = 1) -> bool:
+    """Verify a user supplied TOTP code allowing limited clock skew."""
+
+    if not secret or not code:
+        return False
+
+    normalized = _normalize_code(code)
+    if not normalized.isdigit():
+        return False
+
+    current_time = time.time()
+    for step in range(-valid_window, valid_window + 1):
+        comparison_time = current_time + step * _PERIOD
+        candidate = _generate_otp(secret, comparison_time)
+        if hmac.compare_digest(candidate, normalized):
+            return True
+    return False
+
+
+__all__ = ["generate_secret", "build_otpauth_url", "verify_code"]

--- a/backend/migrations/versions/0003_add_totp_fields.py
+++ b/backend/migrations/versions/0003_add_totp_fields.py
@@ -1,0 +1,41 @@
+"""add totp fields to users
+
+Revision ID: 0003_add_totp_fields
+Revises: 0002_add_user_profile_fields
+Create Date: 2025-02-14 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0003_add_totp_fields"
+down_revision = "0002_add_user_profile_fields"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("totp_secret", sa.String(length=255), nullable=True))
+    op.add_column(
+        "users",
+        sa.Column("totp_secret_pending", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "users",
+        sa.Column(
+            "totp_enabled",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    op.execute("UPDATE users SET totp_enabled = FALSE WHERE totp_enabled IS NULL")
+    op.alter_column("users", "totp_enabled", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("users", "totp_enabled")
+    op.drop_column("users", "totp_secret_pending")
+    op.drop_column("users", "totp_secret")

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -16,6 +16,7 @@ const normalizeUser = (user) => {
   const lastName = user.last_name ?? null;
   const phoneNumber = user.phone_number ?? null;
   const displayName = [firstName, lastName].filter(Boolean).join(" ") || user.username;
+  const totpEnabled = Boolean(user.totp_enabled);
 
   return {
     id: user.id,
@@ -27,6 +28,7 @@ const normalizeUser = (user) => {
     firstName,
     lastName,
     phoneNumber,
+    totpEnabled,
   };
 };
 
@@ -143,10 +145,10 @@ export const UserProvider = ({ children }) => {
   }, [refreshAccessToken, fetchCurrentUser, clearSession]);
 
   const login = useCallback(
-    async (username, password) => {
+    async (username, password, totpCode) => {
       setLoading(true);
       try {
-        const authResponse = await api.login(username, password);
+        const authResponse = await api.login(username, password, totpCode);
         if (!authResponse?.access_token) {
           throw new Error("No access token returned by server");
         }


### PR DESCRIPTION
## Summary
- add change-password and TOTP setup/disable endpoints with supporting schema updates and migration
- require TOTP codes on login and implement deterministic TOTP generation utility
- expose password and TOTP management UI in settings and handle 2FA during sign-in

## Testing
- pytest
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690d3fe995c8832e872727ffb0e697ce)