### PR TITLE
Normalize Whisper model names before loading

### DIFF
--- a/backend/app/services/asr/whisper_service.py
+++ b/backend/app/services/asr/whisper_service.py
@@ -15,15 +15,45 @@ class WhisperService:
     """Thin wrapper around the Whisper model to provide cached inference."""
 
     def __init__(self, model_name: str) -> None:
-        self._model_name = model_name
+        self._configured_model_name = model_name
+        self._model_name = self._resolve_model_name(model_name)
         self._model_lock = threading.Lock()
         self._model: Optional[whisper.Whisper] = None
+
+    @staticmethod
+    def _resolve_model_name(model_name: str) -> str:
+        """Resolve a configured Whisper model name to one recognised by the library."""
+
+        available_models = set(whisper.available_models())
+        if model_name in available_models:
+            return model_name
+
+        alias_prefix = "whisper-"
+        if model_name.startswith(alias_prefix):
+            candidate = model_name[len(alias_prefix) :]
+            if candidate in available_models:
+                logger.info(
+                    "Normalised Whisper model name from '%s' to '%s'", model_name, candidate
+                )
+                return candidate
+
+        raise RuntimeError(
+            "Unknown Whisper model '%s'. Available models are: %s"
+            % (model_name, ", ".join(sorted(available_models)))
+        )
 
     def _get_model(self) -> whisper.Whisper:
         if self._model is None:
             with self._model_lock:
                 if self._model is None:
-                    logger.info("Loading Whisper model '%s'", self._model_name)
+                    if self._configured_model_name == self._model_name:
+                        logger.info("Loading Whisper model '%s'", self._model_name)
+                    else:
+                        logger.info(
+                            "Loading Whisper model '%s' (configured as '%s')",
+                            self._model_name,
+                            self._configured_model_name,
+                        )
                     self._model = whisper.load_model(self._model_name)
         return self._model
 

--- a/backend/tests/test_whisper_service.py
+++ b/backend/tests/test_whisper_service.py
@@ -1,0 +1,28 @@
+import pytest
+
+from app.services.asr import whisper_service
+
+
+def test_resolve_model_name_alias(monkeypatch):
+    monkeypatch.setattr(
+        whisper_service.whisper,
+        "available_models",
+        lambda: ["tiny", "large"],
+    )
+
+    service = whisper_service.WhisperService("whisper-large")
+
+    assert service._model_name == "large"
+
+
+def test_resolve_model_name_invalid(monkeypatch):
+    monkeypatch.setattr(
+        whisper_service.whisper,
+        "available_models",
+        lambda: ["tiny", "large"],
+    )
+
+    with pytest.raises(RuntimeError) as exc:
+        whisper_service.WhisperService._resolve_model_name("unknown-model")
+
+    assert "Unknown Whisper model 'unknown-model'" in str(exc.value)


### PR DESCRIPTION
## Summary
- normalize configured Whisper model names to supported variants and improve logging when aliases are used
- add unit tests covering alias resolution and invalid model handling for the Whisper service

## Testing
- pytest backend/tests/test_whisper_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690dd6061f8c832e9fb4a1f6f9bff2a1)