### PR TITLE
Add lightweight Whisper configuration

### DIFF
--- a/backend/app/services/asr/whisper_service.py
+++ b/backend/app/services/asr/whisper_service.py
@@ -25,6 +25,24 @@ class WhisperService:
         """Resolve a configured Whisper model name to one recognised by the library."""
 
         available_models = set(whisper.available_models())
+
+        # Provide a couple of friendlier aliases for commonly requested
+        # configurations.  The "lightweight" alias gives us a small-footprint
+        # model that runs comfortably on developer laptops.
+        alias_map = {
+            "whisper-lightweight": "small",
+            "lightweight": "small",
+        }
+        if model_name in alias_map:
+            alias_target = alias_map[model_name]
+            if alias_target in available_models:
+                logger.info(
+                    "Normalised Whisper model alias '%s' to '%s'",
+                    model_name,
+                    alias_target,
+                )
+                return alias_target
+
         if model_name in available_models:
             return model_name
 

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -43,7 +43,7 @@ class Settings(BaseSettings):
                 origins.add(localhost_variant)
         return sorted(origins)
 
-    ASR_MODEL: str = "whisper-large"  # TODO: used by AI team
+    ASR_MODEL: str = "whisper-lightweight"
 
     class Config:
         env_file = ".env"

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - STORAGE_KEY=minioadmin
       - STORAGE_SECRET=minioadmin
       - FRONTEND_ORIGIN=http://localhost:3000
-      - ASR_MODEL=whisper-large
+      - ASR_MODEL=whisper-lightweight
     ports:
       - "8000:8000"
     depends_on:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -20,7 +20,7 @@ os.environ.setdefault("STORAGE_BUCKET", "test-bucket")
 os.environ.setdefault("STORAGE_KEY", "minioadmin")
 os.environ.setdefault("STORAGE_SECRET", "minioadmin")
 os.environ.setdefault("FRONTEND_ORIGIN", "http://localhost:3000")
-os.environ.setdefault("ASR_MODEL", "whisper-large")
+os.environ.setdefault("ASR_MODEL", "whisper-lightweight")
 
 from app.domain.models import Base  # noqa: E402
 

--- a/backend/tests/test_whisper_service.py
+++ b/backend/tests/test_whisper_service.py
@@ -7,12 +7,24 @@ def test_resolve_model_name_alias(monkeypatch):
     monkeypatch.setattr(
         whisper_service.whisper,
         "available_models",
-        lambda: ["tiny", "large"],
+        lambda: ["tiny", "small", "large"],
     )
 
-    service = whisper_service.WhisperService("whisper-large")
+    service = whisper_service.WhisperService("whisper-small")
 
-    assert service._model_name == "large"
+    assert service._model_name == "small"
+
+
+def test_resolve_model_name_lightweight_alias(monkeypatch):
+    monkeypatch.setattr(
+        whisper_service.whisper,
+        "available_models",
+        lambda: ["tiny", "small", "large"],
+    )
+
+    service = whisper_service.WhisperService("whisper-lightweight")
+
+    assert service._model_name == "small"
 
 
 def test_resolve_model_name_invalid(monkeypatch):


### PR DESCRIPTION
## Summary
- map the new `whisper-lightweight` alias to the small Whisper model
- default configuration, docker compose, and tests now reference the lightweight alias

## Testing
- pytest tests/test_whisper_service.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e3b60db5c832e9adcd6f819ec093d)