### PR TITLE
Limit Whisper service to tiny models

### DIFF
--- a/backend/app/services/asr/whisper_service.py
+++ b/backend/app/services/asr/whisper_service.py
@@ -11,16 +11,6 @@ from faster_whisper import WhisperModel
 AVAILABLE_MODELS = {
     "tiny",
     "tiny.en",
-    "base",
-    "base.en",
-    "small",
-    "small.en",
-    "medium",
-    "medium.en",
-    "large",
-    "large-v1",
-    "large-v2",
-    "large-v3",
 }
 
 logger = logging.getLogger(__name__)

--- a/backend/tests/test_whisper_service.py
+++ b/backend/tests/test_whisper_service.py
@@ -7,20 +7,20 @@ def test_resolve_model_name_alias(monkeypatch):
     monkeypatch.setattr(
         whisper_service,
         "AVAILABLE_MODELS",
-        {"tiny", "small", "large"},
+        {"tiny", "tiny.en"},
         raising=False,
     )
 
-    service = whisper_service.WhisperService("whisper-small")
+    service = whisper_service.WhisperService("whisper-tiny")
 
-    assert service._model_name == "small"
+    assert service._model_name == "tiny"
 
 
 def test_resolve_model_name_lightweight_alias(monkeypatch):
     monkeypatch.setattr(
         whisper_service,
         "AVAILABLE_MODELS",
-        {"tiny", "small", "large"},
+        {"tiny", "tiny.en"},
         raising=False,
     )
 
@@ -33,7 +33,7 @@ def test_resolve_model_name_invalid(monkeypatch):
     monkeypatch.setattr(
         whisper_service,
         "AVAILABLE_MODELS",
-        {"tiny", "large"},
+        {"tiny", "tiny.en"},
         raising=False,
     )
 


### PR DESCRIPTION
## Summary
- restrict the available Whisper models to the tiny variants for inference
- update unit tests to align with the reduced model set

## Testing
- pytest backend/tests/test_whisper_service.py *(fails: missing dependency sqlalchemy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e53931f6c832eaa270578a186da11)