### PR TITLE
Stop speech restart loop when microphone access denied

### DIFF
--- a/frontend/src/hooks/useSpeechToText.js
+++ b/frontend/src/hooks/useSpeechToText.js
@@ -37,12 +37,18 @@ const useSpeechToText = (initialOptions = {}) => {
 
   useEffect(() => {
     if (isMicrophoneAvailable === false) {
+      restartOnEndRef.current = false;
       setError("speech-recognition-microphone-unavailable");
     }
   }, [isMicrophoneAvailable]);
 
   useEffect(() => {
     if (!restartOnEndRef.current) {
+      return;
+    }
+
+    if (isMicrophoneAvailable === false) {
+      restartOnEndRef.current = false;
       return;
     }
 
@@ -64,7 +70,7 @@ const useSpeechToText = (initialOptions = {}) => {
         setError(startError?.message ?? "speech-recognition-restart-error");
       }
     }
-  }, [listening]);
+  }, [isMicrophoneAvailable, listening]);
 
   const startListening = useCallback((options = {}) => {
     optionsRef.current = { ...optionsRef.current, ...options };


### PR DESCRIPTION
## Summary
- prevent the speech restart effect from re-triggering when the microphone is unavailable
- reset the auto-restart flag when microphone access is denied so we stop retrying

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e6e2a5094832e8c638362dca90804)