### PR TITLE
Add transcription storage and receptionist selection

### DIFF
--- a/backend/app/api/v1/routes_transcriptions.py
+++ b/backend/app/api/v1/routes_transcriptions.py
@@ -1,0 +1,64 @@
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.domain import repositories, schemas
+from app.domain.models import UserRole
+from app.infra import auth
+from app.infra.db import get_db
+
+router = APIRouter(prefix="/v1/transcriptions", tags=["transcriptions"])
+
+
+@router.post("", response_model=schemas.TranscriptionRead, status_code=status.HTTP_201_CREATED)
+def create_transcription(
+    payload: schemas.TranscriptionCreate,
+    db: Session = Depends(get_db),
+    _: object = Depends(auth.require_roles(UserRole.DOCTOR, UserRole.ADMIN)),
+) -> schemas.TranscriptionRead:
+    patient_identifier = payload.patient_identifier.strip()
+    patient_name = payload.patient_name.strip()
+    transcript_text = payload.transcript_text.strip()
+
+    if not patient_identifier:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Patient identifier is required")
+    if not patient_name:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Patient name is required")
+    if not transcript_text:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Transcript text is required")
+
+    patient_repo = repositories.PatientRepository(db)
+    transcription_repo = repositories.TranscriptionRepository(db)
+    user_repo = repositories.UserRepository(db)
+
+    patient = patient_repo.get_by_identifier(patient_identifier)
+    if patient:
+        patient = patient_repo.update(
+            patient,
+            patient_name=patient_name,
+            patient_date_of_birth=payload.patient_date_of_birth,
+        )
+    else:
+        patient = patient_repo.create(
+            patient_identifier=patient_identifier,
+            patient_name=patient_name,
+            patient_date_of_birth=payload.patient_date_of_birth,
+        )
+
+    receptionist_id = payload.receptionist_id
+    if receptionist_id is not None:
+        receptionist = user_repo.get(receptionist_id)
+        if receptionist is None:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Selected receptionist does not exist")
+        if receptionist.role != UserRole.RECEPTIONIST.value:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Selected user is not a receptionist")
+
+    doctor_specialty = payload.doctor_specialty.strip() if payload.doctor_specialty else None
+
+    transcription = transcription_repo.create(
+        patient_id=patient.id,
+        doctor_specialty=doctor_specialty,
+        transcript_text=transcript_text,
+        receptionist_id=receptionist_id,
+    )
+
+    return schemas.TranscriptionRead.model_validate(transcription)

--- a/backend/app/deps.py
+++ b/backend/app/deps.py
@@ -3,7 +3,13 @@ from functools import lru_cache
 from fastapi import Depends
 from sqlalchemy.orm import Session
 
-from app.domain.repositories import JobRepository, ReportRepository, UserRepository
+from app.domain.repositories import (
+    JobRepository,
+    PatientRepository,
+    ReportRepository,
+    TranscriptionRepository,
+    UserRepository,
+)
 from app.infra.db import get_db
 from app.services.asr.whisper_service import WhisperService
 from app.settings import Settings, get_settings
@@ -23,6 +29,16 @@ def get_job_repository(db: Session = Depends(get_db)) -> JobRepository:
 
 def get_report_repository(db: Session = Depends(get_db)) -> ReportRepository:
     return ReportRepository(db)
+
+
+def get_patient_repository(db: Session = Depends(get_db)) -> PatientRepository:
+    return PatientRepository(db)
+
+
+def get_transcription_repository(
+    db: Session = Depends(get_db),
+) -> TranscriptionRepository:
+    return TranscriptionRepository(db)
 
 
 @lru_cache(maxsize=1)

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -1,8 +1,8 @@
-from datetime import datetime
+from datetime import datetime, date
 from enum import Enum as PyEnum
 from typing import Optional
 
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import Boolean, Column, Date, DateTime, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import declarative_base, relationship
 
 
@@ -12,7 +12,8 @@ Base = declarative_base()
 class UserRole(str, PyEnum):
     ADMIN = "admin"
     DOCTOR = "doctor"
-    ASSISTANT = "transcriptionist"
+    TRANSCRIPTIONIST = "transcriptionist"
+    RECEPTIONIST = "assistant"
 
 
 class User(Base):
@@ -24,7 +25,7 @@ class User(Base):
     last_name: Optional[str] = Column(String(255), nullable=True)
     phone_number: Optional[str] = Column(String(32), nullable=True)
     hashed_password: str = Column(String(255), nullable=False)
-    role: str = Column(String(50), nullable=False, default=UserRole.ASSISTANT.value)
+    role: str = Column(String(50), nullable=False, default=UserRole.TRANSCRIPTIONIST.value)
     totp_secret: Optional[str] = Column(String(255), nullable=True)
     totp_secret_pending: Optional[str] = Column(String(255), nullable=True)
     totp_enabled: bool = Column(Boolean, nullable=False, default=False)
@@ -68,4 +69,40 @@ class Report(Base):
     format: str = Column(String(50), nullable=False)
     output_uri: str = Column(Text, nullable=False)
     created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+
+class Patient(Base):
+    __tablename__ = "patients"
+
+    id: int = Column(Integer, primary_key=True, index=True)
+    patient_identifier: str = Column(String(64), unique=True, nullable=False, index=True)
+    patient_name: str = Column(String(255), nullable=False)
+    patient_date_of_birth: Optional[date] = Column(Date, nullable=True)
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    transcriptions = relationship(
+        "Transcription", back_populates="patient", cascade="all,delete-orphan"
+    )
+
+
+class Transcription(Base):
+    __tablename__ = "transcriptions"
+
+    id: int = Column(Integer, primary_key=True, index=True)
+    patient_id: int = Column(Integer, ForeignKey("patients.id"), nullable=False, index=True)
+    doctor_specialty: Optional[str] = Column(String(255), nullable=True)
+    transcript_text: str = Column(Text, nullable=False)
+    receptionist_id: Optional[int] = Column(
+        Integer, ForeignKey("users.id"), nullable=True, index=True
+    )
+    created_at: datetime = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at: datetime = Column(
+        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False
+    )
+
+    patient = relationship("Patient", back_populates="transcriptions")
+    receptionist = relationship("User")
 

--- a/backend/app/domain/schemas.py
+++ b/backend/app/domain/schemas.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import date, datetime
 from typing import Optional
 
 from pydantic import BaseModel, Field
@@ -45,6 +45,16 @@ class UserRead(UserBase):
     created_at: datetime
     updated_at: datetime
     totp_enabled: bool = False
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserListItem(BaseModel):
+    id: int
+    username: str
+    first_name: Optional[str] = None
+    last_name: Optional[str] = None
+    role: str
 
     model_config = ConfigDict(from_attributes=True)
 
@@ -101,6 +111,43 @@ class ReportRead(BaseModel):
     format: str
     output_uri: str
     created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class PatientBase(BaseModel):
+    patient_identifier: str = Field(min_length=1)
+    patient_name: str = Field(min_length=1)
+    patient_date_of_birth: Optional[date] = None
+
+
+class PatientCreate(PatientBase):
+    pass
+
+
+class PatientRead(PatientBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class TranscriptionBase(BaseModel):
+    doctor_specialty: Optional[str] = None
+    transcript_text: str = Field(min_length=1)
+    receptionist_id: Optional[int] = None
+
+
+class TranscriptionCreate(TranscriptionBase, PatientBase):
+    pass
+
+
+class TranscriptionRead(TranscriptionBase):
+    id: int
+    patient: PatientRead
+    created_at: datetime
+    updated_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.api.v1 import (
     routes_health,
     routes_jobs,
     routes_reports,
+    routes_transcriptions,
     routes_transcribe,
     routes_users,
 )
@@ -34,6 +35,7 @@ app.include_router(routes_health.router)
 app.include_router(routes_auth.router)
 app.include_router(routes_jobs.router)
 app.include_router(routes_reports.router)
+app.include_router(routes_transcriptions.router)
 app.include_router(routes_transcribe.router)
 app.include_router(routes_users.router)
 

--- a/backend/migrations/versions/0004_add_patients_and_transcriptions.py
+++ b/backend/migrations/versions/0004_add_patients_and_transcriptions.py
@@ -1,0 +1,72 @@
+"""add patients and transcriptions tables"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0004"
+down_revision = "0003"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "patients",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("patient_identifier", sa.String(length=64), nullable=False),
+        sa.Column("patient_name", sa.String(length=255), nullable=False),
+        sa.Column("patient_date_of_birth", sa.Date(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+    )
+    op.create_index(
+        "ix_patients_patient_identifier",
+        "patients",
+        ["patient_identifier"],
+        unique=True,
+    )
+    op.create_index("ix_patients_id", "patients", ["id"], unique=False)
+
+    op.create_table(
+        "transcriptions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("patient_id", sa.Integer(), nullable=False),
+        sa.Column("doctor_specialty", sa.String(length=255), nullable=True),
+        sa.Column("transcript_text", sa.Text(), nullable=False),
+        sa.Column("receptionist_id", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["patient_id"], ["patients.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["receptionist_id"], ["users.id"], ondelete="SET NULL"),
+    )
+    op.create_index("ix_transcriptions_id", "transcriptions", ["id"], unique=False)
+    op.create_index(
+        "ix_transcriptions_patient_id",
+        "transcriptions",
+        ["patient_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_transcriptions_receptionist_id",
+        "transcriptions",
+        ["receptionist_id"],
+        unique=False,
+    )
+
+    op.alter_column("patients", "created_at", server_default=None)
+    op.alter_column("patients", "updated_at", server_default=None)
+    op.alter_column("transcriptions", "created_at", server_default=None)
+    op.alter_column("transcriptions", "updated_at", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_index("ix_transcriptions_receptionist_id", table_name="transcriptions")
+    op.drop_index("ix_transcriptions_patient_id", table_name="transcriptions")
+    op.drop_index("ix_transcriptions_id", table_name="transcriptions")
+    op.drop_table("transcriptions")
+
+    op.drop_index("ix_patients_id", table_name="patients")
+    op.drop_index("ix_patients_patient_identifier", table_name="patients")
+    op.drop_table("patients")

--- a/backend/tests/test_transcriptions.py
+++ b/backend/tests/test_transcriptions.py
@@ -1,0 +1,63 @@
+from datetime import date
+
+from app.domain import repositories
+from app.domain.models import UserRole
+
+
+def test_create_transcription_with_patient_and_receptionist(db_session):
+    user_repo = repositories.UserRepository(db_session)
+    patient_repo = repositories.PatientRepository(db_session)
+    transcription_repo = repositories.TranscriptionRepository(db_session)
+
+    receptionist = user_repo.create(
+        username="receptionist1",
+        hashed_password="hashed-password",
+        role=UserRole.RECEPTIONIST.value,
+    )
+
+    patient = patient_repo.create(
+        patient_identifier="PAT-123",
+        patient_name="John Doe",
+        patient_date_of_birth=date(1985, 5, 20),
+    )
+
+    transcription = transcription_repo.create(
+        patient_id=patient.id,
+        doctor_specialty="cardiology",
+        transcript_text="Patient is recovering well.",
+        receptionist_id=receptionist.id,
+    )
+
+    assert transcription.patient_id == patient.id
+    assert transcription.receptionist_id == receptionist.id
+    assert transcription.transcript_text == "Patient is recovering well."
+    assert transcription.patient.patient_name == "John Doe"
+    assert transcription.patient.patient_identifier == "PAT-123"
+
+
+def test_patient_repository_get_by_identifier(db_session):
+    patient_repo = repositories.PatientRepository(db_session)
+
+    patient_repo.create(
+        patient_identifier="PAT-456",
+        patient_name="Jane Smith",
+        patient_date_of_birth=None,
+    )
+
+    stored = patient_repo.get_by_identifier("PAT-456")
+    assert stored is not None
+    assert stored.patient_name == "Jane Smith"
+    assert stored.patient_identifier == "PAT-456"
+
+
+def test_user_repository_list_by_role(db_session):
+    user_repo = repositories.UserRepository(db_session)
+
+    user_repo.create("doc", "hashed", UserRole.DOCTOR.value)
+    user_repo.create("rec-1", "hashed", UserRole.RECEPTIONIST.value)
+    user_repo.create("rec-2", "hashed", UserRole.RECEPTIONIST.value)
+
+    receptionists = user_repo.list_by_role(UserRole.RECEPTIONIST.value)
+
+    assert len(receptionists) == 2
+    assert {user.username for user in receptionists} == {"rec-1", "rec-2"}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -203,6 +203,27 @@ export const logout = async () => {
   return handleResponse(response);
 };
 
+export const listReceptionists = async (token) => {
+  const response = await fetch(`${API_BASE_URL}/v1/users/receptionists`, {
+    method: "GET",
+    headers: buildHeaders(token),
+    credentials: "include",
+  });
+
+  return handleResponse(response);
+};
+
+export const createTranscription = async (token, payload) => {
+  const response = await fetch(`${API_BASE_URL}/v1/transcriptions`, {
+    method: "POST",
+    headers: buildHeaders(token, { "Content-Type": "application/json" }),
+    credentials: "include",
+    body: JSON.stringify(payload),
+  });
+
+  return handleResponse(response);
+};
+
 export const apiConfig = {
   API_BASE_URL,
 };


### PR DESCRIPTION
## Summary
- introduce patients and transcriptions tables with corresponding repositories, schemas, and migration
- add API support to create transcriptions and list receptionists for selection
- enhance the new transcription workflow to fetch receptionists, capture assignments, and persist submissions

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e6de95364832eafac1772664f96df)