### PR TITLE
Fix transcription export utilities

### DIFF
--- a/frontend/src/utils/exportToPdf.jsx
+++ b/frontend/src/utils/exportToPdf.jsx
@@ -1,32 +1,55 @@
 import jsPDF from "jspdf";
 
-const exportToPDF = (
+const DEFAULT_MARGIN_LEFT = 10;
+const DEFAULT_LINE_HEIGHT = 10;
+
+const getSafeValue = (value) =>
+  value === undefined || value === null || value === "" ? "N/A" : value;
+
+const exportToPDF = ({
   patientName,
   patientId,
   dateOfBirth,
   specialty,
-  transcript
-) => {
-  const doc = new jsPDF();
+  transcript,
+} = {}) => {
+  const doc = new jsPDF({ unit: "mm", format: "a4" });
 
   // Title
   doc.setFontSize(16);
-  doc.text("Medical Transcription", 10, 10);
+  doc.text("Medical Transcription", DEFAULT_MARGIN_LEFT, DEFAULT_MARGIN_LEFT);
 
   // Patient Info
   doc.setFontSize(12);
-  doc.text(`Patient Name: ${patientName}`, 10, 20);
-  doc.text(`Patient ID: ${patientId}`, 10, 30);
-  doc.text(`Date of Birth: ${dateOfBirth}`, 10, 40);
-  doc.text(`Specialty: ${specialty}`, 10, 50);
+  doc.text(
+    `Patient Name: ${getSafeValue(patientName)}`,
+    DEFAULT_MARGIN_LEFT,
+    DEFAULT_MARGIN_LEFT + DEFAULT_LINE_HEIGHT
+  );
+  doc.text(
+    `Patient ID: ${getSafeValue(patientId)}`,
+    DEFAULT_MARGIN_LEFT,
+    DEFAULT_MARGIN_LEFT + DEFAULT_LINE_HEIGHT * 2
+  );
+  doc.text(
+    `Date of Birth: ${getSafeValue(dateOfBirth)}`,
+    DEFAULT_MARGIN_LEFT,
+    DEFAULT_MARGIN_LEFT + DEFAULT_LINE_HEIGHT * 3
+  );
+  doc.text(
+    `Specialty: ${getSafeValue(specialty)}`,
+    DEFAULT_MARGIN_LEFT,
+    DEFAULT_MARGIN_LEFT + DEFAULT_LINE_HEIGHT * 4
+  );
 
   // Transcript Section
   doc.setFontSize(12);
-  doc.text("Transcript:", 10, 65);
+  const transcriptHeaderOffset = DEFAULT_MARGIN_LEFT + DEFAULT_LINE_HEIGHT * 5.5;
+  doc.text("Transcript:", DEFAULT_MARGIN_LEFT, transcriptHeaderOffset);
 
-  // Multi-line transcript text wrapping
-  const splitText = doc.splitTextToSize(transcript, 180);
-  doc.text(splitText, 10, 75);
+  const safeTranscript = getSafeValue(transcript).toString();
+  const splitText = doc.splitTextToSize(safeTranscript, 180);
+  doc.text(splitText, DEFAULT_MARGIN_LEFT, transcriptHeaderOffset + DEFAULT_LINE_HEIGHT);
 
   doc.save("transcription.pdf");
 };

--- a/frontend/src/utils/exportToWord.jsx
+++ b/frontend/src/utils/exportToWord.jsx
@@ -1,13 +1,21 @@
 import { Document, Packer, Paragraph, TextRun } from "docx";
 import { saveAs } from "file-saver";
 
-const exportToWord = (
+const getSafeValue = (value) =>
+  value === undefined || value === null || value === "" ? "N/A" : value;
+
+const exportToWord = ({
   patientName,
   patientId,
   dateOfBirth,
   specialty,
-  transcript
-) => {
+  transcript,
+} = {}) => {
+  const transcriptLines = getSafeValue(transcript)
+    .toString()
+    .split(/\r?\n/)
+    .map((line) => new Paragraph(line || ""));
+
   const doc = new Document({
     sections: [
       {
@@ -22,15 +30,15 @@ const exportToWord = (
               }),
             ],
           }),
-          new Paragraph(`Patient Name: ${patientName}`),
-          new Paragraph(`Patient ID: ${patientId}`),
-          new Paragraph(`Date of Birth: ${dateOfBirth}`),
-          new Paragraph(`Specialty: ${specialty}`),
+          new Paragraph(`Patient Name: ${getSafeValue(patientName)}`),
+          new Paragraph(`Patient ID: ${getSafeValue(patientId)}`),
+          new Paragraph(`Date of Birth: ${getSafeValue(dateOfBirth)}`),
+          new Paragraph(`Specialty: ${getSafeValue(specialty)}`),
           new Paragraph({ text: "" }), // spacer
           new Paragraph({
             children: [new TextRun({ text: "Transcript:", bold: true })],
           }),
-          new Paragraph(transcript || ""), // handle empty transcript
+          ...transcriptLines,
         ],
       },
     ],


### PR DESCRIPTION
## Summary
- update the PDF export helper to consume a single payload object and guard against missing values
- update the Word export helper to accept the same payload shape and preserve multi-line transcripts

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e76580eb0832ea2fbe6e2103b226e)