### PR TITLE
Append confirmed transcript segments

### DIFF
--- a/frontend/src/pages/newtranscription/NewTranscription.jsx
+++ b/frontend/src/pages/newtranscription/NewTranscription.jsx
@@ -372,10 +372,18 @@ export const NewTranscription = () => {
       return;
     }
 
-    setTranscript(normalizedTranscript);
+    setTranscript((currentTranscript) => {
+      const existingTranscript = (currentTranscript ?? "").trim();
+
+      if (!existingTranscript) {
+        return normalizedTranscript;
+      }
+
+      return `${existingTranscript}\n\n${normalizedTranscript}`;
+    });
     resetTranscript();
     setPendingTranscript("");
-    message.success("Transcript confirmed from the latest recording");
+    message.success("Transcript appended from the latest recording");
   };
 
   const saveDraft = async () => {


### PR DESCRIPTION
## Summary
- append newly confirmed recordings to any previously confirmed transcript instead of overwriting it
- update the confirmation message to reflect the append behavior

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e8b3c1ce0832e8e8cbf6ffad7e9c8)