### PR TITLE
Add doctor specialty field

### DIFF
--- a/backend/app/api/v1/routes_auth.py
+++ b/backend/app/api/v1/routes_auth.py
@@ -25,7 +25,16 @@ def register(
         role_value = UserRole(payload.role).value
     except ValueError as exc:
         raise HTTPException(status_code=400, detail='Invalid role') from exc
-    user = user_repo.create(payload.username, hashed, role_value)
+    specialty = payload.specialty.strip() if payload.specialty else None
+    if role_value != UserRole.DOCTOR.value:
+        specialty = None
+
+    user = user_repo.create(
+        payload.username,
+        hashed,
+        role_value,
+        specialty=specialty,
+    )
     return schemas.UserRead.from_orm(user)
 
 

--- a/backend/app/api/v1/routes_users.py
+++ b/backend/app/api/v1/routes_users.py
@@ -37,6 +37,9 @@ def update_me(
                 value = None
         sanitized[field] = value
 
+    if "specialty" in sanitized and current_user.role != UserRole.DOCTOR.value:
+        sanitized.pop("specialty")
+
     updated_user = user_repo.update(current_user, **sanitized)
     return schemas.UserRead.from_orm(updated_user)
 

--- a/backend/app/domain/models.py
+++ b/backend/app/domain/models.py
@@ -26,6 +26,7 @@ class User(Base):
     phone_number: Optional[str] = Column(String(32), nullable=True)
     hashed_password: str = Column(String(255), nullable=False)
     role: str = Column(String(50), nullable=False, default=UserRole.TRANSCRIPTIONIST.value)
+    specialty: Optional[str] = Column(String(255), nullable=True)
     totp_secret: Optional[str] = Column(String(255), nullable=True)
     totp_secret_pending: Optional[str] = Column(String(255), nullable=True)
     totp_enabled: bool = Column(Boolean, nullable=False, default=False)

--- a/backend/app/domain/repositories.py
+++ b/backend/app/domain/repositories.py
@@ -24,8 +24,23 @@ class UserRepository:
             .all()
         )
 
-    def create(self, username: str, hashed_password: str, role: str) -> models.User:
-        user = models.User(username=username, hashed_password=hashed_password, role=role)
+    def create(
+        self,
+        username: str,
+        hashed_password: str,
+        role: str,
+        specialty: Optional[str] = None,
+    ) -> models.User:
+        normalized_specialty = specialty.strip() if isinstance(specialty, str) else None
+        if not normalized_specialty:
+            normalized_specialty = None
+
+        user = models.User(
+            username=username,
+            hashed_password=hashed_password,
+            role=role,
+            specialty=normalized_specialty,
+        )
         self.db.add(user)
         self.db.commit()
         self.db.refresh(user)

--- a/backend/app/domain/schemas.py
+++ b/backend/app/domain/schemas.py
@@ -28,6 +28,7 @@ class UserBase(BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     phone_number: Optional[str] = None
+    specialty: Optional[str] = None
 
 
 class UserCreate(UserBase):
@@ -38,6 +39,7 @@ class UserUpdate(BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     phone_number: Optional[str] = None
+    specialty: Optional[str] = None
 
 
 class UserRead(UserBase):
@@ -55,6 +57,7 @@ class UserListItem(BaseModel):
     first_name: Optional[str] = None
     last_name: Optional[str] = None
     role: str
+    specialty: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/backend/migrations/versions/0005_add_user_specialty.py
+++ b/backend/migrations/versions/0005_add_user_specialty.py
@@ -1,0 +1,18 @@
+"""add user specialty"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0005_add_user_specialty"
+down_revision = "0004_add_patients_and_transcriptions"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("specialty", sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("users", "specialty")

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -9,7 +9,12 @@ from app.infra import auth
 
 def test_create_and_get_job(db_session: Session, monkeypatch) -> None:
     user_repo = repositories.UserRepository(db_session)
-    user_db = user_repo.create("clinician", auth.hash_password("securepass"), "doctor")
+    user_db = user_repo.create(
+        "clinician",
+        auth.hash_password("securepass"),
+        "doctor",
+        specialty="Cardiology",
+    )
 
     dummy_queue = types.SimpleNamespace(enqueued=[])  # type: ignore[attr-defined]
 

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -7,7 +7,12 @@ from app.infra import auth
 
 def test_create_and_fetch_report(db_session: Session, monkeypatch) -> None:
     user_repo = repositories.UserRepository(db_session)
-    doctor = user_repo.create("dr-report", auth.hash_password("securepass"), "doctor")
+    doctor = user_repo.create(
+        "dr-report",
+        auth.hash_password("securepass"),
+        "doctor",
+        specialty="Radiology",
+    )
 
     stored = {}
 

--- a/backend/tests/test_transcriptions.py
+++ b/backend/tests/test_transcriptions.py
@@ -53,9 +53,11 @@ def test_patient_repository_get_by_identifier(db_session):
 def test_user_repository_list_by_role(db_session):
     user_repo = repositories.UserRepository(db_session)
 
-    user_repo.create("doc", "hashed", UserRole.DOCTOR.value)
+    doctor = user_repo.create("doc", "hashed", UserRole.DOCTOR.value, specialty="Cardiology")
     user_repo.create("rec-1", "hashed", UserRole.RECEPTIONIST.value)
     user_repo.create("rec-2", "hashed", UserRole.RECEPTIONIST.value)
+
+    assert doctor.specialty == "Cardiology"
 
     receptionists = user_repo.list_by_role(UserRole.RECEPTIONIST.value)
 

--- a/frontend/src/context/UserContext.jsx
+++ b/frontend/src/context/UserContext.jsx
@@ -15,6 +15,7 @@ const normalizeUser = (user) => {
   const firstName = user.first_name ?? null;
   const lastName = user.last_name ?? null;
   const phoneNumber = user.phone_number ?? null;
+  const specialty = user.specialty ?? null;
   const displayName = [firstName, lastName].filter(Boolean).join(" ") || user.username;
   const totpEnabled = Boolean(user.totp_enabled);
 
@@ -28,6 +29,7 @@ const normalizeUser = (user) => {
     firstName,
     lastName,
     phoneNumber,
+    specialty,
     totpEnabled,
   };
 };

--- a/frontend/src/pages/profile/Profile.jsx
+++ b/frontend/src/pages/profile/Profile.jsx
@@ -29,7 +29,11 @@ export const Profile = () => {
   const email = user?.email ?? "Not provided";
   const phone = user?.phoneNumber ?? user?.phone ?? "Not provided";
   const role = user?.role ?? "Member";
-  const specialty = user?.specialty ?? "General";
+  const isDoctor = user?.role === "doctor";
+  const specialtyValue = typeof user?.specialty === "string" ? user.specialty.trim() : "";
+  const specialty = isDoctor
+    ? specialtyValue || "Not specified"
+    : specialtyValue || "General Practice";
   const username = user?.username ?? "Not provided";
 
   const personalDetails = [
@@ -76,10 +80,12 @@ export const Profile = () => {
               <h1 className="text-3xl font-semibold text-foreground">{displayName}</h1>
               <p className="text-muted-foreground">{email}</p>
               <div className="flex flex-wrap items-center justify-center gap-2 md:justify-start">
-                <Tag color="blue" className="flex items-center gap-2">
-                  <BriefcaseMedical className="h-4 w-4" />
-                  <span>{specialty}</span>
-                </Tag>
+                {(isDoctor || specialtyValue) && (
+                  <Tag color="blue" className="flex items-center gap-2">
+                    <BriefcaseMedical className="h-4 w-4" />
+                    <span>{specialty}</span>
+                  </Tag>
+                )}
                 <Tag color="green" className="flex items-center gap-2 capitalize">
                   <ShieldCheck className="h-4 w-4" />
                   <span>{role}</span>


### PR DESCRIPTION
## Summary
- add a specialty field to users including database migration and schema updates
- allow doctor registration and profile updates to persist specialty information while preventing other roles from modifying it
- surface doctor specialty through the frontend profile/settings pages and adjust related tests

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690e9dc2491c832e8c194fad3a68f361)