### PR TITLE
Implement job history and review queue responses

### DIFF
--- a/backend/app/api/v1/routes_jobs.py
+++ b/backend/app/api/v1/routes_jobs.py
@@ -31,6 +31,28 @@ def list_jobs(
     return [schemas.JobRead.from_orm(job) for job in jobs]
 
 
+@router.get("/history", response_model=schemas.JobHistoryResponse)
+def get_job_history(
+    current_user: User = Depends(auth.get_current_user),
+    job_repo: repositories.JobRepository = Depends(deps.get_job_repository),
+):
+    jobs = job_repo.list_for_user(current_user.id)
+    job_items = [schemas.JobRead.from_orm(job) for job in jobs]
+    stats = schemas.JobStats.from_jobs(job_items)
+    return schemas.JobHistoryResponse(jobs=job_items, stats=stats)
+
+
+@router.get("/review-queue", response_model=schemas.JobQueueResponse)
+def get_review_queue(
+    current_user: User = Depends(auth.get_current_user),
+    job_repo: repositories.JobRepository = Depends(deps.get_job_repository),
+):
+    jobs = job_repo.list_for_review_queue(current_user.id)
+    job_items = [schemas.JobRead.from_orm(job) for job in jobs]
+    stats = schemas.JobQueueStats.from_jobs(job_items)
+    return schemas.JobQueueResponse(jobs=job_items, stats=stats)
+
+
 @router.get("/{job_id}", response_model=schemas.JobRead)
 def get_job(
     job_id: int,

--- a/backend/app/domain/repositories.py
+++ b/backend/app/domain/repositories.py
@@ -76,6 +76,19 @@ class JobRepository:
             .all()
         )
 
+    def list_for_review_queue(self, user_id: int):
+        queue_statuses = (
+            models.JobStatus.PENDING.value,
+            models.JobStatus.PROCESSING.value,
+            models.JobStatus.COMPLETED.value,
+        )
+        return (
+            self.db.query(models.Job)
+            .filter(models.Job.user_id == user_id, models.Job.status.in_(queue_statuses))
+            .order_by(models.Job.created_at.asc())
+            .all()
+        )
+
     def update_status(self, job_id: int, status: str, output_uri: Optional[str] = None) -> Optional[models.Job]:
         job = self.get(job_id)
         if job:

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -1,9 +1,11 @@
 import types
+from collections import Counter
 
 from sqlalchemy.orm import Session
 
 from app.api.v1 import routes_jobs
 from app.domain import repositories, schemas
+from app.domain.models import JobStatus
 from app.infra import auth
 
 
@@ -38,4 +40,79 @@ def test_create_and_get_job(db_session: Session, monkeypatch) -> None:
 
     job_detail = routes_jobs.get_job(job_read.id, current_user=user_db, job_repo=job_repo)
     assert job_detail.id == job_read.id
+
+
+def test_job_history_stats(db_session: Session) -> None:
+    user_repo = repositories.UserRepository(db_session)
+    user_db = user_repo.create(
+        "clinician-history",
+        auth.hash_password("securepass"),
+        "doctor",
+    )
+
+    job_repo = repositories.JobRepository(db_session)
+    job_processing = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
+    job_completed = job_repo.create(
+        user_db.id,
+        schemas.JobCreate(type="transcription", input_uri="s3://bucket/audio.wav"),
+    )
+    job_failed = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
+
+    job_repo.update_status(job_processing.id, JobStatus.PROCESSING.value)
+    job_repo.update_status(
+        job_completed.id,
+        JobStatus.COMPLETED.value,
+        output_uri="s3://bucket/result.txt",
+    )
+    job_repo.update_status(job_failed.id, JobStatus.FAILED.value)
+
+    history = routes_jobs.get_job_history(current_user=user_db, job_repo=job_repo)
+
+    assert history.stats.total == 3
+    assert history.stats.processing == 1
+    assert history.stats.completed == 1
+    assert history.stats.failed == 1
+    assert history.stats.in_queue == 1
+    assert history.stats.ready_for_review == 1
+    assert history.stats.unknown == 0
+    assert len(history.jobs) == 3
+
+    returned_statuses = Counter(job.status for job in history.jobs)
+    assert returned_statuses[JobStatus.PROCESSING.value] == 1
+    assert returned_statuses[JobStatus.COMPLETED.value] == 1
+    assert returned_statuses[JobStatus.FAILED.value] == 1
+
+
+def test_review_queue_filters_statuses(db_session: Session) -> None:
+    user_repo = repositories.UserRepository(db_session)
+    user_db = user_repo.create(
+        "clinician-review",
+        auth.hash_password("securepass"),
+        "doctor",
+    )
+
+    job_repo = repositories.JobRepository(db_session)
+    job_pending = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
+    job_processing = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
+    job_completed = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
+    job_failed = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
+
+    job_repo.update_status(job_processing.id, JobStatus.PROCESSING.value)
+    job_repo.update_status(job_completed.id, JobStatus.COMPLETED.value)
+    job_repo.update_status(job_failed.id, JobStatus.FAILED.value)
+
+    queue = routes_jobs.get_review_queue(current_user=user_db, job_repo=job_repo)
+
+    assert len(queue.jobs) == 3
+    assert {job.id for job in queue.jobs} == {
+        job_pending.id,
+        job_processing.id,
+        job_completed.id,
+    }
+    assert queue.stats.total == 3
+    assert queue.stats.pending == 1
+    assert queue.stats.processing == 1
+    assert queue.stats.completed == 1
+    assert queue.stats.in_progress == 2
+    assert queue.stats.ready_for_review == 1
 


### PR DESCRIPTION
## Summary
- add repository helper to load jobs queued for review
- expose new /v1/jobs/history and /v1/jobs/review-queue endpoints that include statistics
- extend job schemas with reusable stats serializers and cover the behaviour in tests

## Testing
- Tests not run (environment lacks required Python packages)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690eb037a4108326ac821e48cda2c260)