### PR TITLE
Link transcription jobs to assigned reviewers

### DIFF
--- a/backend/app/api/v1/routes_jobs.py
+++ b/backend/app/api/v1/routes_jobs.py
@@ -60,7 +60,10 @@ def get_job(
     job_repo: repositories.JobRepository = Depends(deps.get_job_repository),
 ):
     job = job_repo.get(job_id)
-    if not job or job.user_id != current_user.id:
+    if not job or (
+        job.created_by_id != current_user.id
+        and job.assignee_id != current_user.id
+    ):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
     return schemas.JobRead.from_orm(job)
 

--- a/backend/app/domain/schemas.py
+++ b/backend/app/domain/schemas.py
@@ -87,6 +87,8 @@ class TOTPStatus(BaseModel):
 class JobBase(BaseModel):
     type: str
     input_uri: Optional[str] = None
+    transcription_id: Optional[int] = None
+    assignee_id: Optional[int] = None
 
 
 class JobCreate(JobBase):
@@ -97,6 +99,7 @@ class JobRead(JobBase):
     id: int
     status: str
     output_uri: Optional[str] = None
+    created_by_id: int
     created_at: datetime
     updated_at: datetime
 

--- a/backend/migrations/versions/0006_update_jobs_with_transcription_links.py
+++ b/backend/migrations/versions/0006_update_jobs_with_transcription_links.py
@@ -1,0 +1,56 @@
+"""update jobs with transcription links"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.drop_index("ix_jobs_user_id")
+        batch_op.alter_column("user_id", new_column_name="created_by_id")
+        batch_op.create_index("ix_jobs_created_by_id", ["created_by_id"])
+
+        batch_op.add_column(sa.Column("assignee_id", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("transcription_id", sa.Integer(), nullable=True))
+
+        batch_op.create_index("ix_jobs_assignee_id", ["assignee_id"])
+        batch_op.create_index("ix_jobs_transcription_id", ["transcription_id"])
+
+        batch_op.create_foreign_key(
+            "fk_jobs_assignee_id_users",
+            "users",
+            ["assignee_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        batch_op.create_foreign_key(
+            "fk_jobs_transcription_id_transcriptions",
+            "transcriptions",
+            ["transcription_id"],
+            ["id"],
+            ondelete="CASCADE",
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.drop_constraint(
+            "fk_jobs_transcription_id_transcriptions", type_="foreignkey"
+        )
+        batch_op.drop_constraint("fk_jobs_assignee_id_users", type_="foreignkey")
+
+        batch_op.drop_index("ix_jobs_transcription_id")
+        batch_op.drop_index("ix_jobs_assignee_id")
+        batch_op.drop_index("ix_jobs_created_by_id")
+
+        batch_op.drop_column("transcription_id")
+        batch_op.drop_column("assignee_id")
+
+        batch_op.alter_column("created_by_id", new_column_name="user_id")
+        batch_op.create_index("ix_jobs_user_id", ["user_id"])

--- a/backend/tests/test_jobs.py
+++ b/backend/tests/test_jobs.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import Session
 
 from app.api.v1 import routes_jobs
 from app.domain import repositories, schemas
-from app.domain.models import JobStatus
+from app.domain.models import JobStatus, UserRole
 from app.infra import auth
 
 
@@ -33,6 +33,7 @@ def test_create_and_get_job(db_session: Session, monkeypatch) -> None:
     job_in = schemas.JobCreate(type="transcription", input_uri="s3://bucket/audio.wav")
     job_read = routes_jobs.create_job(job_in, current_user=user_db, job_repo=job_repo)
     assert job_read.type == "transcription"
+    assert job_read.created_by_id == user_db.id
     assert dummy_queue.enqueued
 
     jobs = routes_jobs.list_jobs(current_user=user_db, job_repo=job_repo)
@@ -40,6 +41,7 @@ def test_create_and_get_job(db_session: Session, monkeypatch) -> None:
 
     job_detail = routes_jobs.get_job(job_read.id, current_user=user_db, job_repo=job_repo)
     assert job_detail.id == job_read.id
+    assert job_detail.created_by_id == user_db.id
 
 
 def test_job_history_stats(db_session: Session) -> None:
@@ -51,12 +53,18 @@ def test_job_history_stats(db_session: Session) -> None:
     )
 
     job_repo = repositories.JobRepository(db_session)
-    job_processing = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
-    job_completed = job_repo.create(
-        user_db.id,
-        schemas.JobCreate(type="transcription", input_uri="s3://bucket/audio.wav"),
+    job_processing = job_repo.create(
+        created_by_id=user_db.id,
+        job_in=schemas.JobCreate(type="transcription"),
     )
-    job_failed = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
+    job_completed = job_repo.create(
+        created_by_id=user_db.id,
+        job_in=schemas.JobCreate(type="transcription", input_uri="s3://bucket/audio.wav"),
+    )
+    job_failed = job_repo.create(
+        created_by_id=user_db.id,
+        job_in=schemas.JobCreate(type="transcription"),
+    )
 
     job_repo.update_status(job_processing.id, JobStatus.PROCESSING.value)
     job_repo.update_status(
@@ -92,10 +100,18 @@ def test_review_queue_filters_statuses(db_session: Session) -> None:
     )
 
     job_repo = repositories.JobRepository(db_session)
-    job_pending = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
-    job_processing = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
-    job_completed = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
-    job_failed = job_repo.create(user_db.id, schemas.JobCreate(type="transcription"))
+    job_pending = job_repo.create(
+        created_by_id=user_db.id, job_in=schemas.JobCreate(type="transcription")
+    )
+    job_processing = job_repo.create(
+        created_by_id=user_db.id, job_in=schemas.JobCreate(type="transcription")
+    )
+    job_completed = job_repo.create(
+        created_by_id=user_db.id, job_in=schemas.JobCreate(type="transcription")
+    )
+    job_failed = job_repo.create(
+        created_by_id=user_db.id, job_in=schemas.JobCreate(type="transcription")
+    )
 
     job_repo.update_status(job_processing.id, JobStatus.PROCESSING.value)
     job_repo.update_status(job_completed.id, JobStatus.COMPLETED.value)
@@ -115,4 +131,48 @@ def test_review_queue_filters_statuses(db_session: Session) -> None:
     assert queue.stats.completed == 1
     assert queue.stats.in_progress == 2
     assert queue.stats.ready_for_review == 1
+
+
+def test_jobs_visible_to_assignee(db_session: Session) -> None:
+    user_repo = repositories.UserRepository(db_session)
+    doctor = user_repo.create(
+        "doctor-owner",
+        auth.hash_password("securepass"),
+        UserRole.DOCTOR.value,
+    )
+    receptionist = user_repo.create(
+        "assistant-user",
+        auth.hash_password("securepass"),
+        UserRole.RECEPTIONIST.value,
+    )
+
+    patient_repo = repositories.PatientRepository(db_session)
+    patient = patient_repo.create(
+        patient_identifier="PAT-001",
+        patient_name="Alice Patient",
+    )
+    transcription_repo = repositories.TranscriptionRepository(db_session)
+    transcription = transcription_repo.create(
+        patient_id=patient.id,
+        doctor_specialty="cardiology",
+        transcript_text="Example transcript",
+        receptionist_id=receptionist.id,
+    )
+
+    job_repo = repositories.JobRepository(db_session)
+    job = job_repo.create(
+        created_by_id=doctor.id,
+        job_in=schemas.JobCreate(
+            type="transcription",
+            transcription_id=transcription.id,
+            assignee_id=receptionist.id,
+        ),
+    )
+
+    jobs_for_assignee = job_repo.list_for_user(receptionist.id)
+    assert {item.id for item in jobs_for_assignee} == {job.id}
+
+    retrieved = routes_jobs.get_job(job.id, current_user=receptionist, job_repo=job_repo)
+    assert retrieved.id == job.id
+    assert retrieved.assignee_id == receptionist.id
 


### PR DESCRIPTION
## Summary
- add creator, assignee, and transcription relationships to job models and schemas
- automatically create jobs when doctors submit transcriptions and restrict job visibility to creators and assignees
- update migrations and tests to cover the new job workflow and permissions

## Testing
- pytest *(fails: missing SQLAlchemy dependency in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6910491b1ae88326918472ecf6b7cfae)