### PR TITLE
Add Docker-based local development stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,20 @@
+# Backend application configuration
+ENV=development
+SECRET_KEY=changeme
+FRONTEND_ORIGIN=http://localhost:3000
+ASR_MODEL=whisper-tiny
+
+# Database credentials
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=postgres
+POSTGRES_DB=postgres
+DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres
+
+# Message broker connection (Redis)
+BROKER_URL=redis://redis:6379/0
+
+# Object storage credentials (MinIO)
+STORAGE_ENDPOINT=http://minio:9000
+STORAGE_BUCKET=transcriptions
+STORAGE_KEY=minioadmin
+STORAGE_SECRET=minioadmin

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,16 +1,37 @@
+# syntax=docker/dockerfile:1
+# ------------------------
+# Backend application image
+# ------------------------
+# Start from a slim Python base image that includes the runtime needed for FastAPI.
 FROM python:3.11-slim
 
+# Ensure Python output is sent straight to the terminal (useful for logging).
 ENV PYTHONUNBUFFERED=1
+
+# Set the working directory inside the container where the app will live.
 WORKDIR /app
 
+# ------------------------
+# Install Python dependencies
+# ------------------------
+# Copy the project dependency definition files first so Docker can cache this layer.
 COPY pyproject.toml poetry.lock* ./
+
+# Install Poetry and use it to install application dependencies without creating a virtualenv.
 RUN pip install --no-cache-dir poetry && \
     poetry config virtualenvs.create false && \
     poetry install --no-interaction --no-ansi
 
+# ------------------------
+# Copy application source code
+# ------------------------
 COPY app ./app
 COPY migrations ./migrations
 COPY alembic.ini ./alembic.ini
 
+# ------------------------
+# Runtime configuration
+# ------------------------
+# Expose the port used by Uvicorn and set the default command to run the API server.
 EXPOSE 8000
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,89 @@
+# ------------------------
+# Application stack definition
+# ------------------------
+# This docker-compose file orchestrates the backend API, frontend SPA, and supporting services.
+version: "3.9"
+
+services:
+  backend:
+    # Build the FastAPI backend image using the Dockerfile in the backend directory.
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: medical-transcription-backend
+    # Load common configuration values from the shared .env file.
+    env_file:
+      - .env
+    environment:
+      # Pass through variables that need to be available at runtime.
+      DATABASE_URL: ${DATABASE_URL}
+      BROKER_URL: ${BROKER_URL}
+      SECRET_KEY: ${SECRET_KEY}
+      STORAGE_ENDPOINT: ${STORAGE_ENDPOINT}
+      STORAGE_BUCKET: ${STORAGE_BUCKET}
+      STORAGE_KEY: ${STORAGE_KEY}
+      STORAGE_SECRET: ${STORAGE_SECRET}
+      FRONTEND_ORIGIN: ${FRONTEND_ORIGIN}
+      ASR_MODEL: ${ASR_MODEL}
+    depends_on:
+      - db
+      - redis
+      - minio
+    ports:
+      # Expose the API on localhost:8000.
+      - "8000:8000"
+    volumes:
+      # Mount the migrations for easier iteration during development (optional).
+      - ./backend/migrations:/app/migrations
+
+  frontend:
+    # Build the React frontend image using the Dockerfile in the frontend directory.
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: medical-transcription-frontend
+    depends_on:
+      - backend
+    ports:
+      # Serve the compiled SPA through NGINX on localhost:3000.
+      - "3000:80"
+
+  db:
+    # PostgreSQL database used by the backend service.
+    image: postgres:15
+    container_name: medical-transcription-db
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      # Persist database data between restarts.
+      - pgdata:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+  redis:
+    # Redis instance for background job queuing and caching.
+    image: redis:7
+    container_name: medical-transcription-redis
+    ports:
+      - "6379:6379"
+
+  minio:
+    # MinIO provides S3-compatible object storage for transcription assets.
+    image: minio/minio
+    container_name: medical-transcription-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${STORAGE_KEY}
+      MINIO_ROOT_PASSWORD: ${STORAGE_SECRET}
+    volumes:
+      - minio-data:/data
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+
+volumes:
+  # Named volumes keep stateful service data outside of the containers.
+  pgdata:
+  minio-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1
+# ------------------------
+# Frontend build stage
+# ------------------------
+# Use the official Node.js image to install dependencies and build the React/Vite app.
+FROM node:20 AS builder
+
+# Set the working directory inside the container.
+WORKDIR /app
+
+# Copy dependency manifests first so Docker can cache npm install layers.
+COPY package*.json ./
+
+# Install dependencies using npm ci for reproducible builds.
+RUN npm ci
+
+# Copy the rest of the frontend source code and build the production bundle.
+COPY . .
+RUN npm run build
+
+# ------------------------
+# Frontend runtime stage
+# ------------------------
+# Use a lightweight NGINX image to serve the compiled static assets.
+FROM nginx:1.27-alpine
+
+# Copy the build output from the previous stage into NGINX's default web root.
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Expose the HTTP port and run NGINX in the foreground.
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]


### PR DESCRIPTION
## Summary
- add comments to the FastAPI backend Dockerfile for clarity
- add a multi-stage Dockerfile for the React frontend build and runtime
- add a docker-compose stack and example env file to run backend, frontend, and supporting services together

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6910a0e85c8083268a4df4eb9c2bb067)